### PR TITLE
Fixes to Gyre and Nightmare Warps

### DIFF
--- a/TsRandomizer/LevelObjects/Other/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Other/BossEnemy.cs
@@ -40,6 +40,7 @@ namespace TsRandomizer.LevelObjects.Other
 		bool saveHasRun;
 		bool warpHasRun;
 		bool isRandomized;
+		bool nightmareRemoved;
 		int lastWarpLevel;
 		int lastWarpRoom;
 		BossAttributes currentBoss;
@@ -174,6 +175,13 @@ namespace TsRandomizer.LevelObjects.Other
 			if (currentBoss.Index != (int)EBossID.Maw && !eventTypes.Contains(SandStreamerEventType) && !eventTypes.Contains(TimeBreakEventType))
 				return;
 
+			if (!nightmareRemoved)
+			{
+				if (currentBoss.Index == (int)EBossID.Nightmare)
+					Dynamic.SilentKill();
+				nightmareRemoved = true;
+			}
+
 			//abort already triggered scripts
 			((List<ScriptAction>)LevelReflected._activeScripts).Clear();
 			((Queue<DialogueBox>)LevelReflected._dialogueQueue).Clear();
@@ -187,7 +195,7 @@ namespace TsRandomizer.LevelObjects.Other
 			Level.GameSave.LastWarpRoom = lastWarpRoom;
 
 			// Cause Time break
-			if (vanillaBoss.ReturnRoom.LevelId == 15 && currentBoss.Index != (int)EBossID.Nightmare)
+			if (vanillaBoss.ReturnRoom.LevelId == 15)
 			{
 				warpHasRun = true;
 				var enumValue = CutsceneEnumType.GetEnumValue("Alt2_Win");

--- a/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GyrePortalEvent.cs
@@ -1,4 +1,5 @@
-﻿using Timespinner.GameObjects.BaseClasses;
+﻿using Microsoft.Xna.Framework;
+using Timespinner.GameObjects.BaseClasses;
 using TsRandomizer.IntermediateObjects;
 
 namespace TsRandomizer.LevelObjects.Other
@@ -29,7 +30,10 @@ namespace TsRandomizer.LevelObjects.Other
 				LevelReflected.SetLevelSaveInt("GyreDungeonSeed", 1); // Warp to Ifrit
 			}
 			else
+			{
 				Dynamic._isUsable = false;
+				Dynamic.SilentKill();
+			}
 		}
 	}
 }

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -445,6 +445,9 @@ namespace TsRandomizer.LevelObjects
 				level.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level14);
 				level.AsDynamic().SetLevelSaveInt("GyreDungeonSeed", (int)level.GameSave.GetSeed().Value.Id); // Set Gyre enemies
 				BestiaryManager.RefreshBossSaveFlags(level); // Reset boss save flags cleared by Gyre portal
+			    // Set last warp room visited to military hangar warp (instead of crash site)
+				level.GameSave.LastWarpLevel = 10;
+				level.GameSave.LastWarpRoom = 12;
 			}));
 			RoomTriggers.Add(new RoomTrigger(14, 23, (level, itemLocation, seedOptions, gameSettings, screenManager) => {
 				level.JukeBox.StopSong();
@@ -452,7 +455,7 @@ namespace TsRandomizer.LevelObjects
 				{
 					LevelID = 10,
 					RoomID = 0,
-					IsUsingWarp = true,
+					IsUsingWarp = false,
 					IsUsingWhiteFadeOut = true,
 					FadeInTime = 0.5f,
 					FadeOutTime = 0.25f

--- a/TsRandomizer/Screens/MinimapScreen.cs
+++ b/TsRandomizer/Screens/MinimapScreen.cs
@@ -26,7 +26,9 @@ namespace TsRandomizer.Screens
 		{
 			new Roomkey(5, 5),
 			new Roomkey(8, 13),
-			new Roomkey(9, 7)
+			new Roomkey(9, 7),
+			new Roomkey(14, 4),
+			new Roomkey(14, 5),
 		};
 
 		static readonly Roomkey[] GyreRooms =
@@ -60,7 +62,8 @@ namespace TsRandomizer.Screens
 		static readonly Roomkey[] FalseWarpRooms =
 		{
 			new Roomkey(11, 4), // Lab cabinet
-			new Roomkey(2, 51) // Backer memory room
+			new Roomkey(2, 51), // Backer memory room
+			new Roomkey(10, 0) // Military Hangar
 		};
 
 		ItemLocationMap itemLocations;
@@ -195,7 +198,7 @@ namespace TsRandomizer.Screens
 
 			foreach (var roomkey in FalseWarpRooms)
 				foreach (var block in GetRoom(roomkey).Blocks.Values)
-					block.IsTimespinner = true;
+					block.IsBoss = true;
 		}
 
 		public override void Update(GameTime gameTime, InputState input)


### PR DESCRIPTION
- Fixes issue where using a warp shard after entering the Gyre loop placed you at the portal, not at a valid warp room (defaults to military hangar instead)
- Per request, marks the Gyre Portals on the map as red boss dots rather than yellow Timespinner dots
- Fixes issue with boss rando where Nightmare could cause an early credits sequence, by removing it from play at a certain point in its death script
- Per above fix, re-enables Nightmare at Prince/Vol spot's ability to cause a Time Break (previously playing the cutscene guaranteed it was long enough to hit the above bug) 

Note: being able to warp out of the Gyre while the doors are unlocked is expected vanilla behavior, these are miniboss rooms and follow the same warp logic as them, warps are not allowed when the doors are locked.