### PR TITLE
Add Dad Percent Flag

### DIFF
--- a/TsRandomizer/LevelObjects/Other/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Other/BossEnemy.cs
@@ -40,7 +40,9 @@ namespace TsRandomizer.LevelObjects.Other
 		bool saveHasRun;
 		bool warpHasRun;
 		bool isRandomized;
+		bool isDadFinalBoss;
 		bool nightmareRemoved;
+		bool isFinalBoss;
 		int lastWarpLevel;
 		int lastWarpRoom;
 		BossAttributes currentBoss;
@@ -55,6 +57,8 @@ namespace TsRandomizer.LevelObjects.Other
 		protected override void Initialize(SeedOptions options)
 		{
 			isRandomized = Level.GameSave.GetSettings().BossRando.Value;
+			isDadFinalBoss = options.DadPercent;
+			isFinalBoss = false;
 			int argument = 0;
 			if (TypedObject.EnemyType == EEnemyTileType.EmperorBoss)
 			{
@@ -118,10 +122,14 @@ namespace TsRandomizer.LevelObjects.Other
 			EDirection facing = vanillaBoss.IsFacingLeft ? EDirection.East : EDirection.West;
 			Level.PlayCue(ESFX.FoleyWarpGyreOut);
 
+			// Return room is credits if the final boss was defeated
+			RoomItemKey returnRoom = isFinalBoss ? 
+				new RoomItemKey(16, 27) : new RoomItemKey(vanillaBoss.ReturnRoom.LevelId, vanillaBoss.ReturnRoom.RoomId);
+
 			Level.RequestChangeLevel(new LevelChangeRequest
 			{
-				LevelID = vanillaBoss.ReturnRoom.LevelId,
-				RoomID = vanillaBoss.ReturnRoom.RoomId,
+				LevelID = returnRoom.LevelId,
+				RoomID = returnRoom.RoomId,
 				IsUsingWarp = true,
 				IsUsingWhiteFadeOut = true,
 				AdditionalBlackScreenTime = 0.5f,
@@ -143,14 +151,17 @@ namespace TsRandomizer.LevelObjects.Other
 
 			if (warpHasRun || Dynamic._deathScriptTimer <= 0) return;
 
-			if (!clearedHasRun && vanillaBoss.Index == (int)EBossID.Nightmare)
+			if (!clearedHasRun)
 			{
-				// Boss is Nightmare
-				var fillingMethod = Level.GameSave.GetFillingMethod();
+				// Set AP goal state if this was the final boss
+				if ((isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nuvius) || (!isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nightmare))
+				{
+					isFinalBoss = true;
+					var fillingMethod = Level.GameSave.GetFillingMethod();
 
-				if (fillingMethod == FillingMethod.Archipelago)
-					Client.SetStatus(ArchipelagoClientState.ClientGoal);
-
+					if (fillingMethod == FillingMethod.Archipelago)
+						Client.SetStatus(ArchipelagoClientState.ClientGoal);
+				}
 				clearedHasRun = true;
 			};
 

--- a/TsRandomizer/LevelObjects/Other/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Other/BossEnemy.cs
@@ -173,6 +173,9 @@ namespace TsRandomizer.LevelObjects.Other
 			
 			if (!isRandomized)
 			{
+				// Trigger teleport during Dad Percent to ensure "!" cutscene at game completion
+				if (isDadFinalBoss && (vanillaBoss.Index == (int)EBossID.Nuvius || vanillaBoss.Index == (int)EBossID.Nightmare))
+					TeleportPlayer();
 				warpHasRun = true;
 				return;
 			}

--- a/TsRandomizer/LevelObjects/Other/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Other/BossEnemy.cs
@@ -58,7 +58,6 @@ namespace TsRandomizer.LevelObjects.Other
 		{
 			isRandomized = Level.GameSave.GetSettings().BossRando.Value;
 			isDadFinalBoss = options.DadPercent;
-			isFinalBoss = false;
 			int argument = 0;
 			if (TypedObject.EnemyType == EEnemyTileType.EmperorBoss)
 			{
@@ -77,6 +76,8 @@ namespace TsRandomizer.LevelObjects.Other
 			vanillaBoss = isRandomized 
 				? BestiaryManager.GetVanillaBoss(Level, bossId) 
 				: currentBoss;
+
+			isFinalBoss = ((isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nuvius) || (!isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nightmare));
 
 			if (!isRandomized)
 				return;
@@ -154,9 +155,8 @@ namespace TsRandomizer.LevelObjects.Other
 			if (!clearedHasRun)
 			{
 				// Set AP goal state if this was the final boss
-				if ((isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nuvius) || (!isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nightmare))
+				if (isFinalBoss)
 				{
-					isFinalBoss = true;
 					var fillingMethod = Level.GameSave.GetFillingMethod();
 
 					if (fillingMethod == FillingMethod.Archipelago)

--- a/TsRandomizer/LevelObjects/RoomTriggers.cs
+++ b/TsRandomizer/LevelObjects/RoomTriggers.cs
@@ -539,7 +539,7 @@ namespace TsRandomizer.LevelObjects
 			}));
 			RoomTriggers.Add(new RoomTrigger(16, 27, (level, itemLocation, seedOptions, gameSettings, screenManager) => {
 				// Post-Nightmare void
-				if (level.GameSave.GetSettings().BossRando.Value)
+				if (level.GameSave.GetSettings().BossRando.Value || seedOptions.DadPercent)
 				{
 					var enumValue = CutsceneEnumType.GetEnumValue("Temple2_End");
 					CreateAndCallCutsceneMethod.InvokeStatic(enumValue, level, new Point(200, 200));

--- a/TsRandomizer/Randomisation/BestiaryManager.cs
+++ b/TsRandomizer/Randomisation/BestiaryManager.cs
@@ -414,7 +414,7 @@ namespace TsRandomizer.Randomisation
 						VisibleName = "Nightmare",
 						SaveName = "IsBossDead_Nightmare",
 						BossRoom = new RoomItemKey(16, 26),
-						ReturnRoom = new RoomItemKey(16, 27),
+						ReturnRoom = new RoomItemKey(16, 5),
 						Position = new Point(376, 176),
 						HP = 6666,
 						XP = 0,

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -191,7 +191,7 @@ namespace TsRandomizer.Randomisation
 			PyramidEntrance = SeedOptions.EnterSandman ? (Gate)R.Teleport : (UpperLab & completeTimespinner);
 			LeftPyramid = PyramidEntrance & R.DoubleJump;
 			RightPyramid = LeftPyramid & R.UpwardDash;
-			Nightmare = RightPyramid & completeTimespinner;
+			Nightmare = SeedOptions.DadPercent ? EmperorsTower : RightPyramid & completeTimespinner;
 		}
 
 		static int CalculateCapacity(SeedOptions options)

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -22,7 +22,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 11, new SeedOptionInfo { Name = "Cantoran", Description = "Cantoran's fight and check are available upon revisiting his room." } },
 			{ 1 << 12, new SeedOptionInfo { Name = "Lore Checks", Description = "Memories in the present and letters in the past contain items." } },
 			{ 1 << 15, new SeedOptionInfo { Name = "Enter Sandman", Description = "Ancient Pyramid is unlocked by the Twin Pyramid Keys, but the final boss door opens if you have all 5 Timespinner pieces." } },
-			{ 1 << 17, new SeedOptionInfo { Name = "Dad Percent", Description = "The win condition is beating the boss of " } },
+			{ 1 << 17, new SeedOptionInfo { Name = "Dad Percent", Description = "The win condition is beating the boss of Emperor's Tower" } },
 			{ 1 << 13, new SeedOptionInfo { Name = "Tournament", Description = "Forces your settings to be the predefined tournament settings." } }
 		};
 

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -22,6 +22,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 11, new SeedOptionInfo { Name = "Cantoran", Description = "Cantoran's fight and check are available upon revisiting his room." } },
 			{ 1 << 12, new SeedOptionInfo { Name = "Lore Checks", Description = "Memories in the present and letters in the past contain items." } },
 			{ 1 << 15, new SeedOptionInfo { Name = "Enter Sandman", Description = "Ancient Pyramid is unlocked by the Twin Pyramid Keys, but the final boss door opens if you have all 5 Timespinner pieces." } },
+			{ 1 << 17, new SeedOptionInfo { Name = "Dad Percent", Description = "The win condition is beating the boss of " } },
 			{ 1 << 13, new SeedOptionInfo { Name = "Tournament", Description = "Forces your settings to be the predefined tournament settings." } }
 		};
 

--- a/TsRandomizer/SeedOptions.cs
+++ b/TsRandomizer/SeedOptions.cs
@@ -26,7 +26,8 @@ namespace TsRandomizer
 		public bool LoreChecks => (Flags & 1 << 12) > 0;
 		public bool Tournament => (Flags & 1 << 13) > 0;
 		public bool EnterSandman => (Flags & 1 << 15) > 0;
-		
+		public bool DadPercent => (Flags & 1 << 17) > 0;
+
 		//Non visable flags
 		public bool Archipelago => (Flags & 1 << 16) > 0;
 
@@ -57,7 +58,8 @@ namespace TsRandomizer
 				{"LoreChecks", 1U << 12},
 				{"Tournament", 1U << 13},
 				//FastPyramid, merged with EnterSandman
-				{"EnterSandman", 1U << 15}
+				{"EnterSandman", 1U << 15},
+				{"DadPercent", 1U << 17}
 			};
 
 			foreach (var kvp in stringToFlagMapping)


### PR DESCRIPTION
Adds support for the **Dad Percent** flag, which makes the win condition of the randomizer beating the boss in Emperor Nuvius' location. This will trigger the AP win condition and roll credits.

If the Nightmare location is fought with this flag on, the player will be warped back to the save room, without triggering the AP win state or rolling the credits.