### PR TITLE
Sprite replacement applies to treasure chest items

### DIFF
--- a/TsRandomizer/LevelObjects/ItemManipulators/TreasureChest.cs
+++ b/TsRandomizer/LevelObjects/ItemManipulators/TreasureChest.cs
@@ -81,6 +81,7 @@ namespace TsRandomizer.LevelObjects.ItemManipulators
 			if (ItemInfo.Identifier.LootType == LootType.Orb || ItemInfo.Identifier.LootType == LootType.Familiar)
 				Level.GameSave.AddItem(Level, ItemInfo.Identifier);
 
+			((Appendage)Dynamic._itemPopupAppendage).ChangeAnimation(ItemInfo.AnimationIndex);
 			OnItemPickup();
 
 			hasDroppedLoot = true;


### PR DESCRIPTION
Performs the same sprite replacement that is seen for freestanding items.

Used for the pyramid key sprites in Unchained Keys and the trap icon in Trapped Chests