### PR TITLE
Add Trapped Chests Flag and Settings

### DIFF
--- a/TsRandomizer/IntermediateObjects/ItemIdentifier.cs
+++ b/TsRandomizer/IntermediateObjects/ItemIdentifier.cs
@@ -126,6 +126,8 @@ namespace TsRandomizer.IntermediateObjects
 				case EInventoryUseItemType.MapReveal1:
 				case EInventoryUseItemType.MapReveal2:
 					return 5; // Twin Pyramid Key
+				case EInventoryUseItemType.PlaceHolderItem1:
+					return 208; // 'starry void' item
 				default:
 					return (int)GetIconFromUseItemMethod.InvokeStatic(UseItem) - 1;
 			}

--- a/TsRandomizer/IntermediateObjects/SingleItemInfo.cs
+++ b/TsRandomizer/IntermediateObjects/SingleItemInfo.cs
@@ -26,11 +26,6 @@ namespace TsRandomizer.IntermediateObjects
 			Identifier = identifier;
 			Unlocks = unlockingMap.GetAllUnlock(identifier);
 			PickupAction = unlockingMap.GetPickupAction(identifier);
-			PickupAction = level => {
-				TrapManager.SparrowTrap(level);
-				};
-
-
 		}
 
 		public override void OnPickup(Level level)

--- a/TsRandomizer/IntermediateObjects/SingleItemInfo.cs
+++ b/TsRandomizer/IntermediateObjects/SingleItemInfo.cs
@@ -26,6 +26,11 @@ namespace TsRandomizer.IntermediateObjects
 			Identifier = identifier;
 			Unlocks = unlockingMap.GetAllUnlock(identifier);
 			PickupAction = unlockingMap.GetPickupAction(identifier);
+			PickupAction = level => {
+				TrapManager.SparrowTrap(level);
+				};
+
+
 		}
 
 		public override void OnPickup(Level level)

--- a/TsRandomizer/LevelObjects/ItemManipulators/TreasureChest.cs
+++ b/TsRandomizer/LevelObjects/ItemManipulators/TreasureChest.cs
@@ -63,7 +63,6 @@ namespace TsRandomizer.LevelObjects.ItemManipulators
 				default:
 					throw new ArgumentOutOfRangeException(nameof(ItemInfo.Identifier.LootType), ItemInfo.Identifier.LootType, $"lootType cannot be droppd by {nameof(TreasureChest)}");
 			}
-
 			var pickedUp = IsPickedUp;
 			Dynamic._isOpened = pickedUp;
 			Dynamic._hasDroppedLoot = pickedUp;
@@ -80,6 +79,10 @@ namespace TsRandomizer.LevelObjects.ItemManipulators
 			// ReSharper disable once PossibleNullReferenceException
 			if (ItemInfo.Identifier.LootType == LootType.Orb || ItemInfo.Identifier.LootType == LootType.Familiar)
 				Level.GameSave.AddItem(Level, ItemInfo.Identifier);
+
+			var animationIndex = ItemInfo.AnimationIndex;
+			var itemPopupAppendage = (Appendage)Dynamic._itemPopupAppendage;
+			itemPopupAppendage.ChangeAnimation(animationIndex);
 
 			OnItemPickup();
 

--- a/TsRandomizer/LevelObjects/ItemManipulators/TreasureChest.cs
+++ b/TsRandomizer/LevelObjects/ItemManipulators/TreasureChest.cs
@@ -80,10 +80,7 @@ namespace TsRandomizer.LevelObjects.ItemManipulators
 			if (ItemInfo.Identifier.LootType == LootType.Orb || ItemInfo.Identifier.LootType == LootType.Familiar)
 				Level.GameSave.AddItem(Level, ItemInfo.Identifier);
 
-			var animationIndex = ItemInfo.AnimationIndex;
-			var itemPopupAppendage = (Appendage)Dynamic._itemPopupAppendage;
-			itemPopupAppendage.ChangeAnimation(animationIndex);
-
+			((Appendage)Dynamic._itemPopupAppendage).ChangeAnimation(ItemInfo.AnimationIndex);
 			OnItemPickup();
 
 			hasDroppedLoot = true;

--- a/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
@@ -17,7 +17,7 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 
 		readonly List<ItemInfo> itemsToRemoveFromGame;
 		readonly List<ItemInfo> itemsToAddToGame;
-		readonly ItemInfo[] genericItems;
+		readonly List<ItemInfo> genericItems;
 
 		protected ItemLocationRandomizer(Seed seed, ItemInfoProvider itemInfoProvider, ItemUnlockingMap unlockingMap)
 		{
@@ -73,7 +73,7 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 				}
 			}
 
-			genericItems = new[]
+			genericItems = new List<ItemInfo>
 			{
 				ItemInfoProvider.Get(EInventoryUseItemType.Potion),
 				ItemInfoProvider.Get(EInventoryUseItemType.HiPotion),
@@ -88,6 +88,8 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 				ItemInfoProvider.Get(EInventoryUseItemType.SandBottle),
 				ItemInfoProvider.Get(EInventoryUseItemType.HiSandBottle)
 			};
+			if (SeedOptions.TrappedChests)
+				genericItems.Add(ItemInfoProvider.Get(EInventoryUseItemType.PlaceHolderItem1);
 		}
 
 		public abstract ItemLocationMap GenerateItemLocationMap(bool isProgressionOnly);

--- a/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/ItemLocationRandomizer.cs
@@ -89,7 +89,7 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 				ItemInfoProvider.Get(EInventoryUseItemType.HiSandBottle)
 			};
 			if (SeedOptions.TrappedChests)
-				genericItems.Add(ItemInfoProvider.Get(EInventoryUseItemType.PlaceHolderItem1);
+				genericItems.Add(ItemInfoProvider.Get(EInventoryUseItemType.PlaceHolderItem1));
 		}
 
 		public abstract ItemLocationMap GenerateItemLocationMap(bool isProgressionOnly);

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -81,7 +81,7 @@ namespace TsRandomizer.Randomisation
 				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.Tablet), R.Tablet),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryOrbType.Eye, EOrbSlot.Passive), R.OculusRift),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryFamiliarType.Kobo), R.Kobo),
-				new UnlockingSpecification(new ItemIdentifier(EInventoryFamiliarType.MerchantCrow), R.MerchantCrow),
+				new UnlockingSpecification(new ItemIdentifier(EInventoryFamiliarType.MerchantCrow), R.MerchantCrow)
 			};
 
 			if (seed.Options.SpecificKeys)
@@ -97,8 +97,8 @@ namespace TsRandomizer.Randomisation
 			if (seed.Options.UnchainedKeys)
 				SetMapRevealPickupAction(random, seed.Options);
 
-			/*if (seed.Options.TrappedChests)
-				SetTrapPickupAction(random, seed.Options);*/
+			if (seed.Options.TrappedChests)
+				SetTrapPickupAction(random, seed.Options);
 		}
 
 		void SetMapRevealPickupAction(Random random, SeedOptions seedOptions) {
@@ -151,6 +151,16 @@ namespace TsRandomizer.Randomisation
 			
 			
 		}
+
+		void SetTrapPickupAction(Random random, SeedOptions seedOptions)
+		{
+			var trapUnlockingSpecification = new UnlockingSpecification(new ItemIdentifier(EInventoryUseItemType.PlaceHolderItem1), R.None);
+			trapUnlockingSpecification.OnPickup = level => {
+				TrapManager.TriggerRandomTrap(level, random);
+			};
+			unlockingSpecifications.Add(trapUnlockingSpecification);
+		}
+
 
 		void MakeKeyCardUnlocksCardSpecific()
 		{

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -97,8 +97,8 @@ namespace TsRandomizer.Randomisation
 			if (seed.Options.UnchainedKeys)
 				SetMapRevealPickupAction(random, seed.Options);
 
-			if (seed.Options.TrappedChests)
-				SetTrapPickupAction(random, seed.Options);
+			/*if (seed.Options.TrappedChests)
+				SetTrapPickupAction(random, seed.Options);*/
 		}
 
 		void SetMapRevealPickupAction(Random random, SeedOptions seedOptions) {
@@ -150,17 +150,6 @@ namespace TsRandomizer.Randomisation
 			}
 			
 			
-		}
-
-		void SetTrapPickupAction(Random random, SeedOptions seedOptions)
-		{
-			var trapUnlockingSpecification = new UnlockingSpecification(new ItemIdentifier(EInventoryUseItemType.MapReveal0), R.None);
-			trapUnlockingSpecification.OnPickup = level => {
-				// TODO put call to trap manager here
-				TimeSpinnerGame.Localizer.OverrideKey("trap_msg", "Trap Triggered!");
-				level.MainHero.Kill();
-			};
-			unlockingSpecifications.Add(trapUnlockingSpecification);
 		}
 
 		void MakeKeyCardUnlocksCardSpecific()

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -96,6 +96,9 @@ namespace TsRandomizer.Randomisation
 
 			if (seed.Options.UnchainedKeys)
 				SetMapRevealPickupAction(random, seed.Options);
+
+			if (seed.Options.TrappedChests)
+				SetTrapPickupAction(random, seed.Options);
 		}
 
 		void SetMapRevealPickupAction(Random random, SeedOptions seedOptions) {
@@ -147,6 +150,17 @@ namespace TsRandomizer.Randomisation
 			}
 			
 			
+		}
+
+		void SetTrapPickupAction(Random random, SeedOptions seedOptions)
+		{
+			var trapUnlockingSpecification = new UnlockingSpecification(new ItemIdentifier(EInventoryUseItemType.MapReveal0), R.None);
+			trapUnlockingSpecification.OnPickup = level => {
+				// TODO put call to trap manager here
+				TimeSpinnerGame.Localizer.OverrideKey("trap_msg", "Trap Triggered!");
+				level.MainHero.Kill();
+			};
+			unlockingSpecifications.Add(trapUnlockingSpecification);
 		}
 
 		void MakeKeyCardUnlocksCardSpecific()

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -98,7 +98,7 @@ namespace TsRandomizer.Randomisation
 				SetMapRevealPickupAction(random, seed.Options);
 
 			if (seed.Options.TrappedChests)
-				SetTrapPickupAction(random, seed.Options);
+				SetTrapPickupAction();
 		}
 
 		void SetMapRevealPickupAction(Random random, SeedOptions seedOptions) {
@@ -152,11 +152,11 @@ namespace TsRandomizer.Randomisation
 			
 		}
 
-		void SetTrapPickupAction(Random random, SeedOptions seedOptions)
+		void SetTrapPickupAction()
 		{
 			var trapUnlockingSpecification = new UnlockingSpecification(new ItemIdentifier(EInventoryUseItemType.PlaceHolderItem1), R.None);
 			trapUnlockingSpecification.OnPickup = level => {
-				TrapManager.TriggerRandomTrap(level, random);
+				TrapManager.TriggerRandomTrap(level);
 			};
 			unlockingSpecifications.Add(trapUnlockingSpecification);
 		}

--- a/TsRandomizer/Randomisation/TrapManager.cs
+++ b/TsRandomizer/Randomisation/TrapManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Timespinner.Core;
@@ -13,6 +14,7 @@ namespace TsRandomizer.Randomisation
 {
 	enum ETrapType
 	{
+		None,
 		MeteorSparrow,
 		Neurotoxin,
 		Chaos,
@@ -23,7 +25,45 @@ namespace TsRandomizer.Randomisation
 
 	static class TrapManager
 	{
-		public static void SparrowTrap(Level level)
+		public static void TriggerRandomTrap(Level level, Random random)
+		{
+			ETrapType[] validTraps = GetValidTraps();
+			// TODO: make random seed varied on chest room/location
+			ETrapType selectedTrap = validTraps[random.Next(validTraps.Length)];
+			TriggerTrap(level, selectedTrap);
+		}
+		public static void TriggerTrap(Level level, ETrapType trapType)
+		{
+			switch (trapType)
+			{
+				case ETrapType.MeteorSparrow:
+					SparrowTrap(level);
+					break;
+				case ETrapType.Neurotoxin:
+					NeurotoxinTrap(level);
+					break;
+				case ETrapType.Chaos:
+					ChaosTrap(level);
+					break;
+				case ETrapType.Poison:
+					PoisonTrap(level);
+					break;
+				default:
+					return;
+			}
+			level.JukeBox.PlayCue(Timespinner.GameAbstractions.ESFX.DoorKeycardError);
+		}
+		static ETrapType[] GetValidTraps()
+		{
+			List<ETrapType> validTraps = new List<ETrapType>();
+			// TODO: assemble list based on settings
+			validTraps.Add(ETrapType.MeteorSparrow);
+
+			if (validTraps.Count == 0)
+				validTraps.Add(ETrapType.None);
+			return validTraps.ToArray();
+		}
+		static void SparrowTrap(Level level)
 		{
 			ObjectTileSpecification enemyTile = new ObjectTileSpecification();
 			enemyTile.Category = EObjectTileCategory.Enemy;
@@ -41,7 +81,21 @@ namespace TsRandomizer.Randomisation
 			enemy = enemyType.CreateInstance(false, new Point(lunaisPos.X - 100, lunaisPos.Y - 50), level, sprite, -1, enemyTile);
 			enemy.AsDynamic()._isAggroed = true;
 			level.AsDynamic().RequestAddObject(enemy);
-			level.JukeBox.PlayCue(Timespinner.GameAbstractions.ESFX.DoorKeycardError);
+		}
+
+		static void NeurotoxinTrap(Level level)
+		{
+
+		}
+
+		static void ChaosTrap(Level level)
+		{
+
+		}
+
+		static void PoisonTrap(Level level)
+		{
+
 		}
 	}
 }

--- a/TsRandomizer/Randomisation/TrapManager.cs
+++ b/TsRandomizer/Randomisation/TrapManager.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Xna.Framework;
-using Timespinner.Core;
 using Timespinner.Core.Specifications;
 using Timespinner.GameAbstractions.Gameplay;
-using Timespinner.GameAbstractions.Inventory;
 using TsRandomizer.Extensions;
 using TsRandomizer.IntermediateObjects;
 using TsRandomizer.Settings;
@@ -27,7 +24,7 @@ namespace TsRandomizer.Randomisation
 	{
 		public static void TriggerRandomTrap(Level level, Random random)
 		{
-			ETrapType[] validTraps = GetValidTraps();
+			ETrapType[] validTraps = GetValidTraps(level);
 			// TODO: make random seed varied on chest room/location
 			ETrapType selectedTrap = validTraps[random.Next(validTraps.Length)];
 			TriggerTrap(level, selectedTrap);
@@ -53,11 +50,18 @@ namespace TsRandomizer.Randomisation
 			}
 			level.JukeBox.PlayCue(Timespinner.GameAbstractions.ESFX.DoorKeycardError);
 		}
-		static ETrapType[] GetValidTraps()
+		static ETrapType[] GetValidTraps(Level level)
 		{
+			SettingCollection gameSettings = level.GameSave.GetSettings();
 			List<ETrapType> validTraps = new List<ETrapType>();
-			// TODO: assemble list based on settings
-			validTraps.Add(ETrapType.MeteorSparrow);
+			if (gameSettings.SparrowTrap.Value)
+				validTraps.Add(ETrapType.MeteorSparrow);
+			if (gameSettings.NeurotoxinTrap.Value)
+				validTraps.Add(ETrapType.Neurotoxin);
+			if (gameSettings.ChaosTrap.Value)
+				validTraps.Add(ETrapType.Chaos);
+			if (gameSettings.PoisonTrap.Value)
+				validTraps.Add(ETrapType.Poison);
 
 			if (validTraps.Count == 0)
 				validTraps.Add(ETrapType.None);
@@ -85,17 +89,24 @@ namespace TsRandomizer.Randomisation
 
 		static void NeurotoxinTrap(Level level)
 		{
-
+			ApplyStatus(level, "NeuroToxin");
 		}
 
 		static void ChaosTrap(Level level)
 		{
-
+			ApplyStatus(level, "Chaos");
 		}
 
 		static void PoisonTrap(Level level)
 		{
-
+			ApplyStatus(level, "Poison");
 		}
+
+		static void ApplyStatus(Level level, string status)
+		{
+			var statusEnumType = TimeSpinnerType.Get("Timespinner.GameObjects.StatusEffects+EStatuseffectType");
+			level.MainHero.AsDynamic().GiveStatusEffect(statusEnumType.GetEnumValue(status), 100);
+		}
+		
 	}
 }

--- a/TsRandomizer/Randomisation/TrapManager.cs
+++ b/TsRandomizer/Randomisation/TrapManager.cs
@@ -26,18 +26,23 @@ namespace TsRandomizer.Randomisation
 	{
 		public static void SparrowTrap(Level level)
 		{
-			var enemyTile = new ObjectTileSpecification
-			{
-				Category = EObjectTileCategory.Enemy,
-				Layer = ETileLayerType.Objects,
-				ObjectID = (int)EEnemyTileType.CastleArcher
-			};
+			ObjectTileSpecification enemyTile = new ObjectTileSpecification();
+			enemyTile.Category = EObjectTileCategory.Enemy;
+			enemyTile.Layer = ETileLayerType.Objects;
+			enemyTile.ObjectID = (int)EEnemyTileType.FlyingCheveux;
+
+			var lunaisPos = level.MainHero.LastPosition;
 			var sprite = level.GCM.SpGyreMeteorSparrow;
-			var enemyType = TimeSpinnerType.Get("Timespinner.GameObjects.Enemies.Monster.GyreMeteorSparrow");
-			var lunaisPos = level.MainHero.Position;
-			var position = new Point(lunaisPos.X + 200, lunaisPos.Y + 200);
-			var sparrow = enemyType.CreateInstance(false, position, level, sprite, enemyTile);
-			level.AsDynamic().RequestAddObject(sparrow);
+			var enemyType = TimeSpinnerType.Get("Timespinner.GameObjects.Enemies.GyreMeteorSparrow");
+			var enemy = enemyType.CreateInstance(false, new Point(lunaisPos.X + 100, lunaisPos.Y - 50), level, sprite, -1, enemyTile);
+			enemy.AsDynamic()._isAggroed = true;
+			level.AsDynamic().RequestAddObject(enemy);
+
+
+			enemy = enemyType.CreateInstance(false, new Point(lunaisPos.X - 100, lunaisPos.Y - 50), level, sprite, -1, enemyTile);
+			enemy.AsDynamic()._isAggroed = true;
+			level.AsDynamic().RequestAddObject(enemy);
+			level.JukeBox.PlayCue(Timespinner.GameAbstractions.ESFX.CsPrologueTableFlip);
 		}
 	}
 }

--- a/TsRandomizer/Randomisation/TrapManager.cs
+++ b/TsRandomizer/Randomisation/TrapManager.cs
@@ -41,7 +41,7 @@ namespace TsRandomizer.Randomisation
 			enemy = enemyType.CreateInstance(false, new Point(lunaisPos.X - 100, lunaisPos.Y - 50), level, sprite, -1, enemyTile);
 			enemy.AsDynamic()._isAggroed = true;
 			level.AsDynamic().RequestAddObject(enemy);
-			level.JukeBox.PlayCue(Timespinner.GameAbstractions.ESFX.CsPrologueTableFlip);
+			level.JukeBox.PlayCue(Timespinner.GameAbstractions.ESFX.DoorKeycardError);
 		}
 	}
 }

--- a/TsRandomizer/Randomisation/TrapManager.cs
+++ b/TsRandomizer/Randomisation/TrapManager.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Timespinner.Core;
+using Timespinner.Core.Specifications;
+using Timespinner.GameAbstractions.Gameplay;
+using Timespinner.GameAbstractions.Inventory;
+using TsRandomizer.Extensions;
+using TsRandomizer.IntermediateObjects;
+using TsRandomizer.Settings;
+
+namespace TsRandomizer.Randomisation
+{
+	enum ETrapType
+	{
+		None,
+		MeteorSparrow,
+		Neurotoxin,
+		Chaos,
+		Poison
+	}
+
+
+
+	static class TrapManager
+	{
+		public static void SparrowTrap(Level level)
+		{
+			var enemyTile = new ObjectTileSpecification
+			{
+				Category = EObjectTileCategory.Enemy,
+				Layer = ETileLayerType.Objects,
+				ObjectID = (int)EEnemyTileType.CastleArcher
+			};
+			var sprite = level.GCM.SpGyreMeteorSparrow;
+			var enemyType = TimeSpinnerType.Get("Timespinner.GameObjects.Enemies.Monster.GyreMeteorSparrow");
+			var lunaisPos = level.MainHero.Position;
+			var position = new Point(lunaisPos.X + 200, lunaisPos.Y + 200);
+			var sparrow = enemyType.CreateInstance(false, position, level, sprite, enemyTile);
+			level.AsDynamic().RequestAddObject(sparrow);
+		}
+	}
+}

--- a/TsRandomizer/Randomisation/TrapManager.cs
+++ b/TsRandomizer/Randomisation/TrapManager.cs
@@ -13,7 +13,6 @@ namespace TsRandomizer.Randomisation
 {
 	enum ETrapType
 	{
-		None,
 		MeteorSparrow,
 		Neurotoxin,
 		Chaos,

--- a/TsRandomizer/Randomisation/TrapManager.cs
+++ b/TsRandomizer/Randomisation/TrapManager.cs
@@ -22,10 +22,10 @@ namespace TsRandomizer.Randomisation
 
 	static class TrapManager
 	{
-		public static void TriggerRandomTrap(Level level, Random random)
+		public static void TriggerRandomTrap(Level level)
 		{
 			ETrapType[] validTraps = GetValidTraps(level);
-			// TODO: make random seed varied on chest room/location
+			Random random = new Random((int)level.GameSave.GetSeed().Value.Id + level.RoomIndex);
 			ETrapType selectedTrap = validTraps[random.Next(validTraps.Length)];
 			TriggerTrap(level, selectedTrap);
 		}
@@ -104,7 +104,7 @@ namespace TsRandomizer.Randomisation
 
 		static void ApplyStatus(Level level, string status)
 		{
-			var statusEnumType = TimeSpinnerType.Get("Timespinner.GameObjects.StatusEffects+EStatuseffectType");
+			var statusEnumType = TimeSpinnerType.Get("Timespinner.GameObjects.StatusEffects.EStatusEffectType");
 			level.MainHero.AsDynamic().GiveStatusEffect(statusEnumType.GetEnumValue(status), 100);
 		}
 		

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -23,8 +23,9 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 12, new SeedOptionInfo { Name = "Lore Checks", Description = "Memories in the present and letters in the past contain items." } },
 			{ 1 << 15, new SeedOptionInfo { Name = "Enter Sandman", Description = "Ancient Pyramid is unlocked by the Twin Pyramid Key, but the final boss door opens if you have all 5 Timespinner pieces." } },
 			{ 1 << 17, new SeedOptionInfo { Name = "Dad Percent", Description = "The win condition is beating the boss of Emperor's Tower" } },
-			{ 1 << 18, new SeedOptionInfo { Name = "Rising Tides", Description = "Random area's are flooded or drained" } },
+			{ 1 << 18, new SeedOptionInfo { Name = "Rising Tides", Description = "Random areas are flooded or drained" } },
 			{ 1 << 19, new SeedOptionInfo { Name = "Unchained Keys", Description = "Start with Twin Pyramid Key, which does not give free warp; warp items for Past, Present, (and ??? with Enter Sandman) can be found." } },
+			{ 1 << 20, new SeedOptionInfo { Name = "Trapped Chests", Description = "Empty chests have traps. Toggle available traps in the 'Traps' settings." } },
 			{ 1 << 13, new SeedOptionInfo { Name = "Tournament", Description = "Forces your settings to be the predefined tournament settings." } }
 		};
 

--- a/TsRandomizer/SeedOptions.cs
+++ b/TsRandomizer/SeedOptions.cs
@@ -30,6 +30,7 @@ namespace TsRandomizer
 		public bool DadPercent => (Flags & 1 << 17) > 0;
 		public bool RisingTides => (Flags & 1 << 18) > 0;
 		public bool UnchainedKeys => (Flags & 1 << 19) > 0;
+		public bool TrappedChests => (Flags & 1 << 20) > 0;
 
 		public SeedOptions(uint flags)
 		{

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -242,6 +242,18 @@ namespace TsRandomizer.Settings
 			if (slotData.TryGetValue("ShowBestiary", out var showBestiary))
 				settings.ShowBestiary.Value = IsTrue(showBestiary);
 
+			if (slotData.TryGetValue("SparrowTrap", out var sparrowTrap))
+				settings.SparrowTrap.Value = IsTrue(sparrowTrap);
+
+			if (slotData.TryGetValue("NeurotoxinTrap", out var neurotoxinTrap))
+				settings.NeurotoxinTrap.Value = IsTrue(neurotoxinTrap);
+
+			if (slotData.TryGetValue("ChaosTrap", out var chaosTrap))
+				settings.ChaosTrap.Value = IsTrue(chaosTrap);
+
+			if (slotData.TryGetValue("PoisonTrap", out var poisonTrap))
+				settings.PoisonTrap.Value = IsTrue(poisonTrap);
+
 			if (slotData.TryGetValue("HpCap", out var hpCap))
 				settings.HpCap.Value = ToInt(hpCap, 999);
 

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -16,6 +16,10 @@ namespace TsRandomizer.Settings
 					s => s.ShopFill, s => s.ShopMultiplier, s => s.ShopWarpShards, s => s.LootPool,
 					s => s.DropRateCategory, s => s.DropRate, s => s.LootTierDistro
 				}},
+			new GameSettingCategoryInfo { Name = "Traps", Description = "Toggles traps available via the Trapped Chests flag.",
+				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
+					s => s.SparrowTrap, s => s.NeurotoxinTrap, s => s.ChaosTrap, s => s.PoisonTrap
+				}},
 			new GameSettingCategoryInfo { Name = "Minimap", Description = "Settings related to minimap colors.",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
 					s => s.PastMinimapColor, s => s.PresentMinimapColor, s => s.PyramidMinimapColor,
@@ -83,6 +87,18 @@ namespace TsRandomizer.Settings
 
 		public OnOffGameSetting ShopWarpShards = new OnOffGameSetting("Always Sell Warp Shards",
 			"Shops always sell warp shards (when keys possessed), ignoring inventory setting.", false);
+
+		public OnOffGameSetting SparrowTrap = new OnOffGameSetting("Meteor Sparrows",
+			"Traps can spawn meteor sparrows.", true, false);
+
+		public OnOffGameSetting NeurotoxinTrap = new OnOffGameSetting("Neurotoxin",
+			"Traps can inflict aura-draining neurotoxin.", true, false);
+
+		public OnOffGameSetting ChaosTrap = new OnOffGameSetting("Chaos",
+			"Traps can cause sand-draining chaos.", true, false);
+
+		public OnOffGameSetting PoisonTrap = new OnOffGameSetting("Poison",
+			"Traps can inflict poison.", true, false);
 
 		public NumberGameSetting NumberOfOnScreenLogLines = new NumberGameSetting("Log Number of Lines",
 			"Max number of messages to show at the bottom left of the screen, 0 to turn onscreen log off", 0, 25, 1, 3, true);

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -125,6 +125,7 @@
     <Compile Include="LevelObjects\Other\DoorTeleportEvent.cs" />
     <Compile Include="LevelObjects\Other\CutsceneForest0.cs" />
     <Compile Include="LevelObjects\Other\GlowingFloorEvent.cs" />
+    <Compile Include="Randomisation\TrapManager.cs" />
     <Compile Include="RisingTides.cs" />
     <Compile Include="Randomisation\BestiaryManager.cs" />
     <Compile Include="Randomisation\HintGenerator.cs" />


### PR DESCRIPTION
- Adds trapped chests flag, which adds empty chests to the filler pool
- Available traps for empty chests can be set in Settings
- Current available traps are Sparrow, Chaos, Neurotoxin, and Poison, and can be expanded later
- If no traps are enabled in settings, the empty chests will simply be empty, no action


For potential AP traps integration in the future, it should be possible to call TrapManager directly as needed.