### PR TITLE
Shop items don't overlap with certain drops

### DIFF
--- a/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
@@ -37,7 +37,7 @@ namespace TsRandomizer.LevelObjects.Other
 			if (fillType == "Random")
 			{
 				var random = new Random((int)seed.Id);
-				for (var i = 0; i < 8; i++)
+				for (var i = 200; i < 208; i++)
 				{
 					var item = Helper.GetAllLoot().SelectRandom(random);
 					// Give half of the items to each era. Needs to be done after the random advances


### PR DESCRIPTION
This adds an offset so that the shop inventory doesn't match the drop contents of the first 8 bestiary entries in certain scenarios.

(Note this was only true when weighted drops are turned off, when drops are weighted, there is not overlap)