### PR TITLE
Add a shop offset to mitigate cases where the shop and drops would match

### DIFF
--- a/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
@@ -37,6 +37,9 @@ namespace TsRandomizer.LevelObjects.Other
 			if (fillType == "Random")
 			{
 				var random = new Random((int)seed.Id);
+				// Offset the selection by 200 to not collide with loot drop item selections
+				for (var i = 0; i < 200; i++)
+					Helper.GetAllLoot().SelectRandom(random);
 				for (var i = 0; i < 8; i++)
 				{
 					var item = Helper.GetAllLoot().SelectRandom(random);

--- a/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
+++ b/TsRandomizer/LevelObjects/Other/MerchantCrowNPC.cs
@@ -36,10 +36,7 @@ namespace TsRandomizer.LevelObjects.Other
 			}
 			if (fillType == "Random")
 			{
-				var random = new Random((int)seed.Id);
-				// Offset the selection by 200 to not collide with loot drop item selections
-				for (var i = 0; i < 200; i++)
-					Helper.GetAllLoot().SelectRandom(random);
+				var random = new Random((int)seed.Id + 1);
 				for (var i = 0; i < 8; i++)
 				{
 					var item = Helper.GetAllLoot().SelectRandom(random);


### PR DESCRIPTION
This adds an offset so that the shop inventory doesn't match the drop contents of the first 8 bestiary entries in certain scenarios.

(Note this was only true when weighted drops are turned off, when drops are weighted, there is not overlap)
