### PR TITLE
Add Copy/Paste Buttons to Seed Selection Menu

### DIFF
--- a/TsRandomizer/Screens/SeedSelection/SeedSelectionMenuScreen.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedSelectionMenuScreen.cs
@@ -69,7 +69,11 @@ namespace TsRandomizer.Screens.SeedSelection
 				MenuEntry.Create("New", OnGenerateSelected),
 				MenuEntry.Create("Flags", OnOptionsSelected),
 				MenuEntry.Create("", () => { }, false),
-				MenuEntry.Create("Settings", OnSettingsSelected)
+				MenuEntry.Create("Settings", OnSettingsSelected),
+				MenuEntry.Create("", () => { }, false),
+				MenuEntry.Create("Copy", OnCopySelected),
+				MenuEntry.Create("", () => { }, false),
+				MenuEntry.Create("Paste", OnPasteSelected)
 			);
 		}
 
@@ -85,9 +89,9 @@ namespace TsRandomizer.Screens.SeedSelection
 			if (input.IsControllHold())
 			{
 				if (input.IsKeyHold(Keys.V) && SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE)
-					GetClipboardSeed();
+					PasteClipboardSeed();
 				else if (input.IsKeyHold(Keys.C))
-					SDL.SDL_SetClipboardText(GetHexString());
+					CopyClipboardSeed();
 			}
 
 			var selectedMenuEntryIndex = Dynamic.SelectedIndex;
@@ -100,7 +104,12 @@ namespace TsRandomizer.Screens.SeedSelection
 			}
 		}
 
-		void GetClipboardSeed()
+		void CopyClipboardSeed()
+		{
+			SDL.SDL_SetClipboardText(GetHexString());
+		}
+
+		void PasteClipboardSeed()
 		{
 			var text = SDL.SDL_GetClipboardText().Trim();
 
@@ -188,6 +197,10 @@ namespace TsRandomizer.Screens.SeedSelection
 
 			ScreenManager.AddScreen(gameSettingsMenu, playerIndex);
 		}
+
+		void OnCopySelected(PlayerIndex playerIndex) => CopyClipboardSeed();
+
+		void OnPasteSelected(PlayerIndex playerIndex) => PasteClipboardSeed();
 
 		internal void OnSeedOptionsUpdated(SeedOptionsCollection options)
 		{


### PR DESCRIPTION
![image](https://github.com/Jarno458/TsRandomizer/assets/32756996/509267f7-8c95-407e-862c-658d524f00b0)
Adds functionality on the on-screen keyboard to match the functionality of the available Ctrl-C and Ctrl-V shortcuts.

![image](https://github.com/Jarno458/TsRandomizer/assets/32756996/d4f38301-d657-497e-85f5-c8c95b45e44b)
