### PR TITLE
Change Cantoran to be an opt-in fight

### DIFF
--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -37,6 +37,7 @@ namespace TsRandomizer.LevelObjects.Monsters
 	class BossEnemy: LevelObject<Monster>
 	{
 		bool songHasRun;
+		bool bossInitialized;
 		bool clearedHasRun;
 		bool saveHasRun;
 		bool warpHasRun;
@@ -57,8 +58,9 @@ namespace TsRandomizer.LevelObjects.Monsters
 
 		protected override void Initialize(Seed seed, SettingCollection settings)
 		{
-			isRandomized = Level.GameSave.GetSettings().BossRando.Value != "Off"; ;
+			isRandomized = Level.GameSave.GetSettings().BossRando.Value != "Off" || Level.ID == 17;
 			isDadFinalBoss = seed.Options.DadPercent;
+			bossInitialized = false;
 			int argument = 0;
 			if (TypedObject.EnemyType == EEnemyTileType.EmperorBoss)
 			{
@@ -89,13 +91,6 @@ namespace TsRandomizer.LevelObjects.Monsters
 
 			Level.JukeBox.StopSong();
 			Level.JukeBox.PlaySong(vanillaBoss.Song);
-		}
-
-		public BossEnemy(Monster typedObject, GameplayScreen gameplayScreen) : base(typedObject, gameplayScreen)
-		{
-			isRandomized = Level.GameSave.GetSettings().BossRando.Value != "Off";
-			if (!isRandomized || !Level.GameSave.GetSaveBool("IsFightingBoss"))
-				return;
 
 			switch (TypedObject.EnemyType)
 			{
@@ -110,6 +105,9 @@ namespace TsRandomizer.LevelObjects.Monsters
 					Dynamic.InitializeMob();
 					Dynamic.EndBossIntroCutscene();
 					break;
+				case EEnemyTileType.CantoranBoss:
+					Dynamic.InitializeMob();
+					break;
 				case EEnemyTileType.VarndagrothBoss:
 					Level.MainHero.TeleportToPoint(new Point(200, 200));
 					Dynamic._spindleItem.SilentKill();
@@ -117,6 +115,10 @@ namespace TsRandomizer.LevelObjects.Monsters
 					Dynamic.StartBattle();
 					break;
 			}
+		}
+
+		public BossEnemy(Monster typedObject, GameplayScreen gameplayScreen) : base(typedObject, gameplayScreen)
+		{	
 		}
 
 		void TeleportPlayer()
@@ -172,7 +174,7 @@ namespace TsRandomizer.LevelObjects.Monsters
 				saveHasRun = true;
 			}
 			
-			if (!isRandomized)
+			if (!isRandomized && vanillaBoss.Index != (int)(EBossID.Cantoran))
 			{
 				// Trigger teleport during Dad Percent to ensure "!" cutscene at game completion
 				if (isDadFinalBoss && (vanillaBoss.Index == (int)EBossID.Nuvius || vanillaBoss.Index == (int)EBossID.Nightmare))

--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -174,7 +174,7 @@ namespace TsRandomizer.LevelObjects.Monsters
 				saveHasRun = true;
 			}
 			
-			if (!isRandomized && vanillaBoss.Index != (int)(EBossID.Cantoran))
+			if (!isRandomized)
 			{
 				// Trigger teleport during Dad Percent to ensure "!" cutscene at game completion
 				if (isDadFinalBoss && (vanillaBoss.Index == (int)EBossID.Nuvius || vanillaBoss.Index == (int)EBossID.Nightmare))

--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -169,6 +169,7 @@ namespace TsRandomizer.LevelObjects.Monsters
 				// Set AP goal state if this was the final boss
 				if (isFinalBoss)
 				{
+					Level.GameSave.SetValue("CreditsActive", true);
 					var fillingMethod = Level.GameSave.GetFillingMethod();
 
 					if (fillingMethod == FillingMethod.Archipelago)

--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -37,7 +37,6 @@ namespace TsRandomizer.LevelObjects.Monsters
 	class BossEnemy: LevelObject<Monster>
 	{
 		bool songHasRun;
-		bool bossInitialized;
 		bool clearedHasRun;
 		bool saveHasRun;
 		bool warpHasRun;
@@ -60,7 +59,6 @@ namespace TsRandomizer.LevelObjects.Monsters
 		{
 			isRandomized = Level.GameSave.GetSettings().BossRando.Value != "Off" || Level.ID == 17;
 			isDadFinalBoss = seed.Options.DadPercent;
-			bossInitialized = false;
 			int argument = 0;
 			if (TypedObject.EnemyType == EEnemyTileType.EmperorBoss)
 			{
@@ -106,7 +104,9 @@ namespace TsRandomizer.LevelObjects.Monsters
 					Dynamic.EndBossIntroCutscene();
 					break;
 				case EEnemyTileType.CantoranBoss:
-					Dynamic.InitializeMob();
+					var dialogScript = Scripts.FirstOrDefault(s => s.AsDynamic().ScriptType == EScriptType.Dialogue);
+					if (dialogScript == null)
+						Dynamic.InitializeMob();
 					break;
 				case EEnemyTileType.VarndagrothBoss:
 					Level.MainHero.TeleportToPoint(new Point(200, 200));

--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -107,6 +107,15 @@ namespace TsRandomizer.LevelObjects.Monsters
 					var dialogScript = Scripts.FirstOrDefault(s => s.AsDynamic().ScriptType == EScriptType.Dialogue);
 					if (dialogScript == null)
 						Dynamic.InitializeMob();
+					// Adjust movement anchors to keep him off the floor
+					Dynamic._destinationNodes = new Point[5]
+					{
+						new Point(72, 180),
+						new Point(328, 180),
+						new Point(200, 96),
+						new Point(200, 144),
+						new Point(200, 180)
+					};
 					break;
 				case EEnemyTileType.VarndagrothBoss:
 					Level.MainHero.TeleportToPoint(new Point(200, 200));

--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -78,7 +78,7 @@ namespace TsRandomizer.LevelObjects.Monsters
 				? BestiaryManager.GetVanillaBoss(Level, bossId) 
 				: currentBoss;
 
-			isFinalBoss = ((isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nuvius) || (!isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nightmare));
+			isFinalBoss = (isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nuvius) || (!isDadFinalBoss && vanillaBoss.Index == (int)EBossID.Nightmare);
 
 			if (!isRandomized)
 				return;

--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -110,11 +110,11 @@ namespace TsRandomizer.LevelObjects.Monsters
 					// Adjust movement anchors to keep him off the floor
 					Dynamic._destinationNodes = new Point[5]
 					{
-						new Point(72, 180),
-						new Point(328, 180),
-						new Point(200, 96),
-						new Point(200, 144),
-						new Point(200, 180)
+						new Point(72, 184),
+						new Point(328, 184),
+						new Point(200, 80),
+						new Point(200, 128),
+						new Point(200, 184)
 					};
 					break;
 				case EEnemyTileType.VarndagrothBoss:

--- a/TsRandomizer/LevelObjects/Other/GlowingFloorEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GlowingFloorEvent.cs
@@ -1,4 +1,5 @@
-﻿using Timespinner.GameAbstractions.Gameplay;
+﻿using System.Linq;
+using Timespinner.GameAbstractions.Gameplay;
 using Timespinner.GameObjects.BaseClasses;
 using TsRandomizer.Extensions;
 using TsRandomizer.IntermediateObjects;
@@ -24,9 +25,23 @@ namespace TsRandomizer.LevelObjects.Other
 
 				return;
 			}
-
-			if (Dynamic.Level.ID == 11 && Level.GameSave.GetSettings().BossRando.Value != "Off")
+			else if (Dynamic.Level.ID == 7)
 			{
+				// Cantoran
+				Dynamic._textPromptOffsetX = -20;
+				var bossName = "Cantoran";
+				if (Level.GameSave.GetSettings().BossRando.Value != "Off")
+				{
+					BossAttributes boss = BestiaryManager.GetReplacedBoss(Level, (int)EBossID.Cantoran);
+					bossName = boss.VisibleName;
+				}
+				Dynamic._textPromptText = $"Fight {bossName}";
+
+				return;
+			}
+			else if (Dynamic.Level.ID == 11 && Level.GameSave.GetSettings().BossRando.Value != "Off")
+			{
+				// Emperors
 				int bossId = Dynamic.PrefabType.ToString() == "L11_SwitchWinderia" ? (int)EBossID.Prince : (int)EBossID.Vol;
 
 				BossAttributes boss = BestiaryManager.GetReplacedBoss(Level, bossId);
@@ -38,29 +53,41 @@ namespace TsRandomizer.LevelObjects.Other
 
 		protected override void OnUpdate()
 		{
-			if (Dynamic.Level.ID != 16)
+			if (Dynamic.Level.ID != 16 && Dynamic.Level.ID != 7)
 				return;
 			if (teleportTriggered)
 				return;
 			if (Scripts.Count != 0)
 			{
-				teleportEnabled = true;
 				Scripts.Clear();
+				teleportEnabled = true;
 			}
+			// Pyramid Entrance
+			int warpLevel = 15;
+			int warpRoom = 0;
+			var song = Timespinner.GameAbstractions.EBGM.Level15;
+			// Cantoran Room
+			if (Dynamic.Level.ID == 7)
+			{
+				warpLevel = 17;
+				warpRoom = 8;
+				song = Timespinner.GameAbstractions.EBGM.Boss06;
+			}
+			
 			if (teleportEnabled && Scripts.Count == 0)
 			{
+				teleportTriggered = true;
 				LevelReflected.JukeBox.StopSong();
 				LevelReflected.RequestChangeLevel(new LevelChangeRequest
 				{
-					LevelID = 15,
-					RoomID = 0,
+					LevelID = warpLevel,
+					RoomID = warpRoom,
 					IsUsingWarp = true,
 					IsUsingWhiteFadeOut = true,
 					FadeInTime = 0.5f,
 					FadeOutTime = 0.25f
 				}); // Return to Pyramid start
-				LevelReflected.JukeBox.PlaySong(Timespinner.GameAbstractions.EBGM.Level15);
-				teleportTriggered = true;
+				LevelReflected.JukeBox.PlaySong(song);
 			}
 		}
 	}

--- a/TsRandomizer/Randomisation/BestiaryManager.cs
+++ b/TsRandomizer/Randomisation/BestiaryManager.cs
@@ -557,6 +557,7 @@ namespace TsRandomizer.Randomisation
 			level.GameSave.SetValue("IsCantoranActive", true);
 			level.GameSave.SetValue("IsEndingABCleared", false);
 			level.GameSave.SetValue("IsLabTSReady", false);
+			level.GameSave.SetValue("CreditsActive", false);
 		}
 
 		public static void RefreshBossSaveFlags(Level level)

--- a/TsRandomizer/Randomisation/BestiaryManager.cs
+++ b/TsRandomizer/Randomisation/BestiaryManager.cs
@@ -224,9 +224,9 @@ namespace TsRandomizer.Randomisation
 						Index = bossId,
 						VisibleName = "Cantoran",
 						SaveName = "IsBossDead_Cantoran",
-						BossRoom = new RoomItemKey(7, 5),
+						BossRoom = new RoomItemKey(17, 8),
 						ReturnRoom = new RoomItemKey(7, 5),
-						Position = new Point(184, 224),
+						Position = new Point(200, 50),
 						HP = 2250,
 						XP = 300,
 						TouchDamage = 54,
@@ -236,7 +236,7 @@ namespace TsRandomizer.Randomisation
 						BossType = TimeSpinnerType.Get("Timespinner.GameObjects.Bosses.CantoranBoss"),
 						Argument = 0,
 						IsFacingLeft = true,
-						ShouldSpawn = false,
+						ShouldSpawn = true,
 						TileId = (int)EEnemyTileType.CantoranBoss
 					};
 				case (int)EBossID.Genza:
@@ -584,7 +584,6 @@ namespace TsRandomizer.Randomisation
 			bool isPinkBirdDead = level.GameSave.GetSaveBool("TSRando_IsPinkBirdDead");
 			bool isCantoranDead = level.GameSave.GetSaveBool("TSRando_IsBossDead_Cantoran") || !level.GameSave.GetSeed().Value.Options.Cantoran;
 			level.GameSave.SetCutsceneTriggered("LakeSerene0_Seykis", isPinkBirdDead);
-			level.GameSave.SetValue("IsCantoranActive", isPinkBirdDead && !isCantoranDead);
 
 			level.GameSave.SetValue("IsEndingABCleared", level.GameSave.GetSaveBool("TSRando_IsBossDead_Emperor"));
 			level.GameSave.SetValue("IsLabTSReady", !labTSUsed && level.GameSave.GetSaveBool("TSRando_IsLabTSReady"));

--- a/TsRandomizer/Randomisation/BestiaryManager.cs
+++ b/TsRandomizer/Randomisation/BestiaryManager.cs
@@ -226,7 +226,7 @@ namespace TsRandomizer.Randomisation
 						SaveName = "IsBossDead_Cantoran",
 						BossRoom = new RoomItemKey(17, 8),
 						ReturnRoom = new RoomItemKey(7, 5),
-						Position = new Point(200, 50),
+						Position = new Point(200, 125),
 						HP = 2250,
 						XP = 300,
 						TouchDamage = 54,

--- a/TsRandomizer/Randomisation/BestiaryManager.cs
+++ b/TsRandomizer/Randomisation/BestiaryManager.cs
@@ -582,8 +582,8 @@ namespace TsRandomizer.Randomisation
 			level.GameSave.SetValue("IsVileteSaved", level.GameSave.GetSaveBool("TSRando_IsVileteSaved"));
 
 			bool isPinkBirdDead = level.GameSave.GetSaveBool("TSRando_IsPinkBirdDead");
-			bool isCantoranDead = level.GameSave.GetSaveBool("TSRando_IsBossDead_Cantoran") || !level.GameSave.GetSeed().Value.Options.Cantoran;
 			level.GameSave.SetCutsceneTriggered("LakeSerene0_Seykis", isPinkBirdDead);
+			level.GameSave.SetValue("IsCantoranActive", false);
 
 			level.GameSave.SetValue("IsEndingABCleared", level.GameSave.GetSaveBool("TSRando_IsBossDead_Emperor"));
 			level.GameSave.SetValue("IsLabTSReady", !labTSUsed && level.GameSave.GetSaveBool("TSRando_IsLabTSReady"));

--- a/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs
@@ -62,7 +62,7 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 		{
 			var level = state.Level;
 
-			SpawnWaterOrGassIfNeeded(state, vanillaBossId == -1 ? (int)GetVanillaBoss(state.RoomKey) : vanillaBossId);
+			SpawnWaterOrGasIfNeeded(state, vanillaBossId == -1 ? (int)GetVanillaBoss(state.RoomKey) : vanillaBossId);
 
 			if ((level.GameSave.GetSettings().BossRando.Value == "Off"
 				|| TargetBossId == -1
@@ -96,7 +96,7 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 			TargetBossId = -1;
 		}
 
-		static void SpawnWaterOrGassIfNeeded(RoomState state, int vanillaBossId)
+		static void SpawnWaterOrGasIfNeeded(RoomState state, int vanillaBossId)
 		{
 			if ((state.Seed.Options.GasMaw && vanillaBossId == (int)EBossID.Maw)
 			    || (vanillaBossId == (int)EBossID.FelineSentry && state.Level.GameSave.GetSaveBool("TSRando_IsVileteSaved")))

--- a/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs
@@ -51,6 +51,9 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 				return EBossID.Sandman;
 			if (roomKey.LevelId == 16 && roomKey.RoomId == 26)
 				return EBossID.Nightmare;
+			// Use this placeholder room for other bosses in the future
+			if (roomKey.LevelId == 17 && roomKey.RoomId == 8)
+				return EBossID.Cantoran;
 
 			return (EBossID)(-1);
 		}
@@ -61,9 +64,10 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 
 			SpawnWaterOrGassIfNeeded(state, vanillaBossId == -1 ? (int)GetVanillaBoss(state.RoomKey) : vanillaBossId);
 
-			if (level.GameSave.GetSettings().BossRando.Value == "Off"
+			if ((level.GameSave.GetSettings().BossRando.Value == "Off"
 				|| TargetBossId == -1
-			    || !level.GameSave.GetSaveBool("IsFightingBoss"))
+				|| !level.GameSave.GetSaveBool("IsFightingBoss"))
+				&& level.ID != 17)
 					return;
 			
 			var vanillaBossInfo = BestiaryManager.GetBossAttributes(level, vanillaBossId);
@@ -105,7 +109,7 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 		}
 
 		protected static void CreateBossWarp(Level level, int vanillaBossId)
-		{
+		{ 
 			if (level.GameSave.GetSettings().BossRando.Value == "Off")
 				return;
 

--- a/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs
@@ -51,7 +51,7 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 				return EBossID.Sandman;
 			if (roomKey.LevelId == 16 && roomKey.RoomId == 26)
 				return EBossID.Nightmare;
-			// Use this placeholder room for other bosses in the future
+			// Generic room - could support other bosses in the future
 			if (roomKey.LevelId == 17 && roomKey.RoomId == 8)
 				return EBossID.Cantoran;
 

--- a/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs
@@ -109,7 +109,7 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 		}
 
 		protected static void CreateBossWarp(Level level, int vanillaBossId)
-		{ 
+		{
 			if (level.GameSave.GetSettings().BossRando.Value == "Off")
 				return;
 

--- a/TsRandomizer/RoomTriggers/Triggers/Bosses/FakeBossRoom.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/Bosses/FakeBossRoom.cs
@@ -1,10 +1,26 @@
-﻿namespace TsRandomizer.RoomTriggers.Triggers.Bosses
+﻿using TsRandomizer.Randomisation;
+namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 {
 	[RoomTriggerTrigger(17, 8)]
 	[RoomTriggerTrigger(17, 13)]
 	class FakeBossRoom : BossRoomTrigger
 	{
-		public override void OnRoomLoad(RoomState roomState) =>
-			SpawnBoss(roomState, TargetBossId);
+		public override void OnRoomLoad(RoomState roomState)
+		{
+			if (roomState.Level.GameSave.GetSaveBool("TSRando_IsBossDead_Sorceress"))
+			{
+				TimeSpinnerGame.Localizer.OverrideKey("q_har_4_can_0",
+					"You must be the one who bested Aelana in combat and convinced her to stop this war.");
+			}
+			else
+			{
+				TimeSpinnerGame.Localizer.OverrideKey("q_har_4_can_1",
+					"You won't stop Aelana, I'll best you in combat!");
+			}
+			if (TargetBossId == -1)
+				TargetBossId = (int)EBossID.Cantoran;
+			base.OnRoomLoad(roomState);
+			return;
+		}
 	}
 }

--- a/TsRandomizer/RoomTriggers/Triggers/Bosses/FakeBossRoom.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/Bosses/FakeBossRoom.cs
@@ -7,6 +7,8 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 	{
 		public override void OnRoomLoad(RoomState roomState)
 		{
+			if (roomState.Level.GameSave.GetSaveBool("CreditsActive"))
+				return;
 			if (roomState.Level.GameSave.GetSaveBool("TSRando_IsBossDead_Sorceress"))
 			{
 				TimeSpinnerGame.Localizer.OverrideKey("q_har_4_can_0",
@@ -20,7 +22,6 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 			if (TargetBossId == -1)
 				TargetBossId = (int)EBossID.Cantoran;
 			base.OnRoomLoad(roomState);
-			return;
 		}
 	}
 }

--- a/TsRandomizer/RoomTriggers/Triggers/Bosses/FakeBossRoom.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/Bosses/FakeBossRoom.cs
@@ -14,7 +14,7 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 			}
 			else
 			{
-				TimeSpinnerGame.Localizer.OverrideKey("q_har_4_can_1",
+				TimeSpinnerGame.Localizer.OverrideKey("q_har_4_can_0",
 					"You won't stop Aelana, I'll best you in combat!");
 			}
 			if (TargetBossId == -1)

--- a/TsRandomizer/RoomTriggers/Triggers/MawGasArea.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/MawGasArea.cs
@@ -4,7 +4,7 @@
 	[RoomTriggerTrigger(8, 13)]
 	[RoomTriggerTrigger(8, 21)]
 	[RoomTriggerTrigger(8, 33)]
-	class MawGassArea : RoomTrigger
+	class MawGasArea : RoomTrigger
 	{
 		public override void OnRoomLoad(RoomState roomState)
 		{

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -19,7 +19,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 8, new SeedOptionInfo { Name = "Inverted", Description = "Start in the past." } },
 			{ 1 << 9, new SeedOptionInfo { Name = "Stinky Maw", Description = "Require Gas Mask for Maw." } },
 			{ 1 << 10, new SeedOptionInfo { Name = "Gyre Archives", Description = "Temporal Gyre locations are in logic. New warps are gated by Merchant Crow and Kobo." } },
-			{ 1 << 11, new SeedOptionInfo { Name = "Cantoran", Description = "Cantoran's fight and reward are available." } },
+			{ 1 << 11, new SeedOptionInfo { Name = "Cantoran", Description = "Cantoran's fight and check are available upon revisiting his room." } },
 			{ 1 << 12, new SeedOptionInfo { Name = "Lore Checks", Description = "Memories in the present and letters in the past contain items." } },
 			{ 1 << 13, new SeedOptionInfo { Name = "Tournament", Description = "Forces your settings to be the predefined tournament settings." } },
 			{ 1 << 15, new SeedOptionInfo { Name = "Enter Sandman", Description = "Ancient Pyramid is unlocked by the Twin Pyramid Key, but the final boss door opens if you have all 5 Timespinner pieces." } },

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -19,7 +19,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 8, new SeedOptionInfo { Name = "Inverted", Description = "Start in the past." } },
 			{ 1 << 9, new SeedOptionInfo { Name = "Stinky Maw", Description = "Require Gas Mask for Maw." } },
 			{ 1 << 10, new SeedOptionInfo { Name = "Gyre Archives", Description = "Temporal Gyre locations are in logic. New warps are gated by Merchant Crow and Kobo." } },
-			{ 1 << 11, new SeedOptionInfo { Name = "Cantoran", Description = "Cantoran's fight and check are available upon revisiting his room." } },
+			{ 1 << 11, new SeedOptionInfo { Name = "Cantoran", Description = "Cantoran's fight and reward are available." } },
 			{ 1 << 12, new SeedOptionInfo { Name = "Lore Checks", Description = "Memories in the present and letters in the past contain items." } },
 			{ 1 << 13, new SeedOptionInfo { Name = "Tournament", Description = "Forces your settings to be the predefined tournament settings." } },
 			{ 1 << 15, new SeedOptionInfo { Name = "Enter Sandman", Description = "Ancient Pyramid is unlocked by the Twin Pyramid Key, but the final boss door opens if you have all 5 Timespinner pieces." } },

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -220,7 +220,7 @@
     <Compile Include="RoomTriggers\Triggers\PyramidKeysRoom.cs" />
     <Compile Include="RoomTriggers\Triggers\LibraryIfritWarp.cs" />
     <Compile Include="RoomTriggers\Triggers\MawDemonGate.cs" />
-    <Compile Include="RoomTriggers\Triggers\MawGassArea.cs" />
+    <Compile Include="RoomTriggers\Triggers\MawGasArea.cs" />
     <Compile Include="RoomTriggers\Triggers\MilitairyHangerGyreWarp.cs" />
     <Compile Include="RoomTriggers\Triggers\PlasmaCrystal.cs" />
     <Compile Include="RoomTriggers\Triggers\PostIfritWarp.cs" />


### PR DESCRIPTION
Rather than immediately triggering a boss fight with Cantoran on re-entering the room, this PR requires the player to prompt the battle to begin

To avoid issues with an increasingly complicated recursive room trigger due to sharing a room with the pink bird quest- this moves Cantoran to a new boss arena, a previously identified generic boss arena.