### PR TITLE
Add Melee Autofire Setting

### DIFF
--- a/TsRandomizer/Extensions/SettingsExtensions.cs
+++ b/TsRandomizer/Extensions/SettingsExtensions.cs
@@ -30,6 +30,8 @@ namespace TsRandomizer.Extensions
 
 			settings.ShowDrops.Value = true;
 
+			settings.MeleeAutofire.Value = false;
+
 			settings.SparrowTrap.Value = true;
 			settings.BeeTrap.Value = true;
 			settings.PoisonTrap.Value = true;

--- a/TsRandomizer/Screens/GameplayScreen.cs
+++ b/TsRandomizer/Screens/GameplayScreen.cs
@@ -38,6 +38,8 @@ namespace TsRandomizer.Screens
 		static readonly Type TitleBackgroundScreenType = TimeSpinnerType
 			.Get("Timespinner.GameStateManagement.Screens.MainMenu.TitleBackgroundScreen");
 
+		static readonly Type GamePadWrapper = TimeSpinnerType.Get("Timespinner.GameAbstractions.GamePadWrapper");
+
 		int hpCap;
 		int levelCap;
 		DeathLinker deathLinkService;
@@ -169,6 +171,9 @@ namespace TsRandomizer.Screens
 			FamiliarManager.Update(Level);
 
 			deathLinkService?.Update(Level, ScreenManager);
+
+			if (Settings.MeleeAutofire.Value)
+				GamePadWrapper.GetProperty("IsMeleeDown").SetValue(Level.MainHero.AsDynamic()._gamePadWrapper, false, null);
 
 			if (Settings.ExtraEarringsXP.Value > 0)
 			{

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -293,6 +293,8 @@ namespace TsRandomizer.Settings
 				SetNumberGameSetting(settings.LevelCap, levelCap);
 			if (slotData.TryGetValue("ExtraEarringsXP", out var extraEarringsXP))
 				SetNumberGameSetting(settings.ExtraEarringsXP, extraEarringsXP);
+			if (slotData.TryGetValue("MeleeAutofire", out var meleeAutofire))
+				settings.MeleeAutofire.Value = IsTrue(meleeAutofire);
 
 			if (slotData.TryGetValue("ShowDrops", out var showDrops))
 				settings.ShowDrops.Value = IsTrue(showDrops);

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -43,7 +43,7 @@ namespace TsRandomizer.Settings
 				}},
 			new GameSettingCategoryInfo { Name = "Other", Description = "Miscellaneous settings",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
-					s => s.ShowBestiary, s => s.ShowDrops, s => s.NoSaveStatues, s => s.EnableMapFromStart
+					s => s.ShowBestiary, s => s.ShowDrops, s => s.MeleeAutofire, s => s.NoSaveStatues, s => s.EnableMapFromStart
 				}}
 		};
 
@@ -203,6 +203,9 @@ namespace TsRandomizer.Settings
 
 		public NumberGameSetting ExtraEarringsXP = new NumberGameSetting("Extra Earrings XP",
 			"Adds additional XP granted by Galaxy Earrings", 0, 24, 1, 0, true);
+
+		public OnOffGameSetting MeleeAutofire = new OnOffGameSetting("Autofire (Melee)",
+			"Holding the melee attack button will attack repeatedly.", false, true);
 
 		public OnOffGameSetting NoSaveStatues = new OnOffGameSetting("No Save Statues",
 			"Breaks all the save statues", false, true);


### PR DESCRIPTION
Adds a new accessibility setting, where holding down the melee attack button will attack as often as possible without needing to mash.

Can be toggled during game.