### PR TITLE
Make Greenwood Forest (Camp) a valid teleport destination

### DIFF
--- a/TsRandomizer/Extensions/LevelExtensions.cs
+++ b/TsRandomizer/Extensions/LevelExtensions.cs
@@ -56,7 +56,7 @@ namespace TsRandomizer.Extensions
 
 		internal static void MarkRoomAsVisited(this Level level, int levelId, int roomId)
 		{
-			var minimapRoom = level.Minimap.Areas[levelId].Rooms[roomId];
+			var minimapRoom = level.Minimap.Areas[levelId].Rooms.Find(x => x.RoomID == roomId);
 
 			minimapRoom.SetKnown(true);
 			minimapRoom.SetVisited(true);

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -20,15 +20,13 @@ namespace TsRandomizer.Randomisation
 		internal R OculusRift;
 		internal R MawGasMask;
 
-		internal Gate RefugeeCamp;
-		internal Gate LakeDesolationLeft;
-
 		internal Gate MultipleSmallJumpsOfNpc;
 		internal Gate DoubleJumpOfNpc;
 		internal Gate ForwardDashDoubleJump;
 		internal Gate LakeDesolationRight;
 
 		//past
+		internal Gate RefugeeCamp;
 		internal Gate LeftSideForestCaves;
 		internal Gate UpperLakeSirine;
 		internal Gate LowerLakeSirine;
@@ -43,6 +41,7 @@ namespace TsRandomizer.Randomisation
 		internal Gate UpperRoyalTower;
 		internal Gate KillMaw;
 		//future
+		internal Gate LakeDesolationLeft;
 		internal Gate UpperLakeDesolation;
 		internal Gate LeftLibrary;
 		internal Gate UpperLeftLibrary;
@@ -154,6 +153,7 @@ namespace TsRandomizer.Randomisation
 						| (R.GateMilitaryGate & (R.CardB | R.CardE))
 					)
 				) //libraryTimespinner
+				| R.GateRefugeeCamp
 				| R.GateLakeSereneLeft
 				| R.GateAccessToPast
 				| R.GateLakeSereneRight

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -103,14 +103,14 @@ namespace TsRandomizer.Randomisation
 
 		protected static readonly TeleporterGate[] PastTeleporterGates =
 		{
-			new TeleporterGate{Gate = R.GateRefugeeCamp, LevelId = 3, RoomId = 6}/*,
+			new TeleporterGate{Gate = R.GateRefugeeCamp, LevelId = 3, RoomId = 6},
 			new TeleporterGate{Gate = R.GateLakeSereneRight, LevelId = 7, RoomId = 31},
 			new TeleporterGate{Gate = R.GateAccessToPast, LevelId = 8, RoomId = 51},
 			new TeleporterGate{Gate = R.GateCastleRamparts, LevelId = 4, RoomId = 23},
 			new TeleporterGate{Gate = R.GateCastleKeep, LevelId = 5, RoomId = 24},
 			new TeleporterGate{Gate = R.GateRoyalTowers, LevelId = 6, RoomId = 0},
 			new TeleporterGate{Gate = R.GateMaw, LevelId = 8, RoomId = 49},
-			new TeleporterGate{Gate = R.GateCavesOfBanishment, LevelId = 8, RoomId = 50}*/
+			new TeleporterGate{Gate = R.GateCavesOfBanishment, LevelId = 8, RoomId = 50}
 		};
 
 		protected static readonly TeleporterGate[] PyramidTeleporterGates =

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -103,15 +103,14 @@ namespace TsRandomizer.Randomisation
 
 		protected static readonly TeleporterGate[] PastTeleporterGates =
 		{
-			//new TeleporterGate{Gate = Requirement.GateLakeSereneLeft, LevelId = 7, RoomId = 30}, //you dont want to spawn with a boss in your face
+			new TeleporterGate{Gate = R.GateRefugeeCamp, LevelId = 3, RoomId = 6}/*,
 			new TeleporterGate{Gate = R.GateLakeSereneRight, LevelId = 7, RoomId = 31},
 			new TeleporterGate{Gate = R.GateAccessToPast, LevelId = 8, RoomId = 51},
-			//new TeleporterGate{Gate = R.GateAccessToPast, LevelId = 3, RoomId = 6}, //Refugee Camp, Unlocking this room doesnt work somehow
 			new TeleporterGate{Gate = R.GateCastleRamparts, LevelId = 4, RoomId = 23},
 			new TeleporterGate{Gate = R.GateCastleKeep, LevelId = 5, RoomId = 24},
 			new TeleporterGate{Gate = R.GateRoyalTowers, LevelId = 6, RoomId = 0},
 			new TeleporterGate{Gate = R.GateMaw, LevelId = 8, RoomId = 49},
-			new TeleporterGate{Gate = R.GateCavesOfBanishment, LevelId = 8, RoomId = 50}
+			new TeleporterGate{Gate = R.GateCavesOfBanishment, LevelId = 8, RoomId = 50}*/
 		};
 
 		protected static readonly TeleporterGate[] PyramidTeleporterGates =
@@ -120,6 +119,15 @@ namespace TsRandomizer.Randomisation
 			new TeleporterGate{Gate = R.GateLeftPyramid, LevelId = 16, RoomId = 12},
 			new TeleporterGate{Gate = R.GateRightPyramid, LevelId = 16, RoomId = 19}
 		};
+
+		// Not enabled at this time
+		/*
+		protected static readonly TeleporterGate[] RiskyTeleporterGates =
+		{
+			new TeleporterGate{Gate = R.GateLakeSereneLeft, LevelId = 7, RoomId = 30}, // Azure Queen Boss
+			new TeleporterGate{Gate = R. , LevelId = 11, RoomId = 33}, // The Lab
+			new TeleporterGate{Gate = R. , LevelId = 12, RoomId = 0}, // Emperor's Tower
+		};*/
 
 		protected readonly LookupDictionary<ItemIdentifier, UnlockingSpecification> UnlockingSpecifications;
 

--- a/TsRandomizer/Randomisation/Requirement.cs
+++ b/TsRandomizer/Randomisation/Requirement.cs
@@ -38,6 +38,7 @@ namespace TsRandomizer.Randomisation
 		public static readonly Requirement Kobo = 1UL << 29;
 		public static readonly Requirement MerchantCrow = 1UL << 30;
 
+		public static readonly Requirement GateRefugeeCamp = 1UL << 42;
 		public static readonly Requirement GateSealedCaves = 1UL << 43;
 		public static readonly Requirement GateMaw = 1UL << 44;
 		public static readonly Requirement GateCavesOfBanishment = 1UL << 45;

--- a/TsRandomizer/Randomisation/WarpNames.cs
+++ b/TsRandomizer/Randomisation/WarpNames.cs
@@ -23,14 +23,14 @@ namespace TsRandomizer.Randomisation
 				return "Lake Desolation";
 
 			//past
+			if (gate.Contains(Requirement.GateRefugeeCamp))
+				return "Refugee Camp";
 			if (gate.Contains(Requirement.GateLakeSereneLeft))
 				return "Azure Queen";
 			if (gate.Contains(Requirement.GateAccessToPast))
 				return "Upper Caves of Banishment";
 			if (gate.Contains(Requirement.GateLakeSereneRight))
 				return "East Lake Serene";
-			//if (gate.Contains(R.))
-			//	return "Refugee Camp";
 			if (gate.Contains(Requirement.GateCastleRamparts))
 				return "Castle Ramparts";
 			if (gate.Contains(Requirement.GateCastleKeep))


### PR DESCRIPTION
Changes the MarkRoomAsVisited to handle edge cases where roomId does not match array index, and adds the Refugee Camp to the warp pool, as it was affected by this limitation.

For documentation completion, adds the remaining three warp rooms as a comment