### PR TITLE
Cantoran Crashing/Weirdness Fix

### DIFF
--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -74,7 +74,7 @@ namespace TsRandomizer.LevelObjects.Monsters
 			int bossId = bestiaryEntry.Index;
 
 			currentBoss = BestiaryManager.GetBossAttributes(Level, bossId);
-			vanillaBoss = isRandomized 
+			vanillaBoss = Level.GameSave.GetSettings().BossRando.Value != "Off"
 				? BestiaryManager.GetBossAttributes(Level, Level.GameSave.GetSaveInt("VanillaBossId")) 
 				: currentBoss;
 


### PR DESCRIPTION
This fixes an issue that would cause the game to crash after fighting Cantoran with certain settings. When the Cantoran fight was moved to be in a separate arena, this line https://github.com/Jarno458/TsRandomizer/blob/master/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs#L60 was changed to take into account the new arena and short circuit the rest of the Initialize logic when starting the Cantoran fight. At the same time, Boss Rando was being reworked to make changes for how the vanilla boss was being looked up that relied on that same isRandomized bool to know if a specific save flag (VanillaBossId) was set, since it needs to use that now in order to know what boss we normally should've been fighting. That flag is only set here https://github.com/Jarno458/TsRandomizer/blob/master/TsRandomizer/RoomTriggers/Triggers/Bosses/BossRoomTrigger.cs#L132 when boss rando is enabled, so it was leading to a situation where if a player had Boss Shuffle disabled it would still be trying to look up the vanilla boss with a save flag that has not been set, which in this case would return the default of the Baby Cheveur https://github.com/Jarno458/TsRandomizer/blob/master/TsRandomizer/Randomisation/BestiaryManager.cs#L517. If the player had bestiary entries hidden by default, this would cause a crash on this line https://github.com/Jarno458/TsRandomizer/blob/master/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs#L188 after defeating Cantoran since it was trying to unlock the bestiary entry for the Baby Cheveur, which doesn't have a BestiaryKey set. If the player had all bestiary entries enabled by default then the Cantoran fight would just never be counted as finished, meaning you could fight over and over again. Now the vanilla boss lookup logic only checks for if boss rando is enabled so that flag should always be set.