### PR TITLE
Change how laser access items are placed

### DIFF
--- a/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
@@ -67,13 +67,6 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 					itemsToAddToGame.Add(ItemInfoProvider.Get(CustomItem.GetIdentifier(CustomItemType.MysteriousWarpBeacon))); // Pyramid
 			}
 
-			if (SeedOptions.PrismBreak)
-			{
-				itemsToAddToGame.Add(ItemInfoProvider.Get(CustomItem.GetIdentifier(CustomItemType.LaserAccessA)));
-				itemsToAddToGame.Add(ItemInfoProvider.Get(CustomItem.GetIdentifier(CustomItemType.LaserAccessI)));
-				itemsToAddToGame.Add(ItemInfoProvider.Get(CustomItem.GetIdentifier(CustomItemType.LaserAccessM)));
-			}
-
 			genericItems = new List<ItemInfo>
 			{
 				ItemInfoProvider.Get(EInventoryUseItemType.Potion),

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -139,7 +139,7 @@ namespace TsRandomizer.Randomisation
 		{
 			Random = new Random((int)seed.Id);
 
-			UnlockingSpecifications = new LookupDictionary<ItemIdentifier, UnlockingSpecification>(32, s => s.Item)
+			UnlockingSpecifications = new LookupDictionary<ItemIdentifier, UnlockingSpecification>(29, s => s.Item)
 			{
 				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.TimespinnerWheel), R.TimespinnerWheel, R.TimeStop),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.DoubleJump), R.DoubleJump, R.TimeStop),
@@ -169,14 +169,17 @@ namespace TsRandomizer.Randomisation
 				new UnlockingSpecification(new ItemIdentifier(EInventoryOrbType.Eye, EOrbSlot.Passive), R.OculusRift),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryFamiliarType.Kobo), R.Kobo),
 				new UnlockingSpecification(new ItemIdentifier(EInventoryFamiliarType.MerchantCrow), R.MerchantCrow),
-				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.PyramidsKey), R.None, R.Teleport), //actual gate is decided later,
-				new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.LaserAccessA), R.LaserA),
-				new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.LaserAccessI), R.LaserI),
-				new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.LaserAccessM), R.LaserM)
+				new UnlockingSpecification(new ItemIdentifier(EInventoryRelicType.PyramidsKey), R.None, R.Teleport) //actual gate is decided later,
 		};
 
 			if (seed.Options.SpecificKeys)
 				MakeKeyCardUnlocksCardSpecific();
+			if (seed.Options.PrismBreak)
+			{
+				UnlockingSpecifications.Add(new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.LaserAccessA), R.LaserA));
+				UnlockingSpecifications.Add(new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.LaserAccessI), R.LaserI));
+				UnlockingSpecifications.Add(new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.LaserAccessM), R.LaserM));
+			}
 		}
 
 		void MakeKeyCardUnlocksCardSpecific()


### PR DESCRIPTION
Fixes issue where laser gates were being included as progression items in seeds that had the prism break flag turned off.