### PR TITLE
Fix Enemizer bug with duplicate Xarion

### DIFF
--- a/TsRandomizer/LevelObjects/Enemizer.cs
+++ b/TsRandomizer/LevelObjects/Enemizer.cs
@@ -16,7 +16,6 @@ namespace TsRandomizer.LevelObjects
 	class Enemizer
 	{
 		static readonly Type BossType = TimeSpinnerType.Get("Timespinner.GameObjects.BaseClasses.BossClass");
-
 		static readonly E[] LargeGroundedEnemies = {
 			E.JumpingCheveuxTank,
 			E.SealDog,
@@ -238,7 +237,7 @@ namespace TsRandomizer.LevelObjects
 			{	
 				if (enemy.EnemyType == EEnemyTileType.JunkSpawner || enemy.EnemyType == EEnemyTileType.LabAdult || enemy.EnemyType == EEnemyTileType.XarionBoss)
 					continue;
-				
+
 				var type = enemy.GetType();
 				if (type.IsSubclassOf(BossType))
 					continue;

--- a/TsRandomizer/LevelObjects/Enemizer.cs
+++ b/TsRandomizer/LevelObjects/Enemizer.cs
@@ -215,8 +215,6 @@ namespace TsRandomizer.LevelObjects
 					FlyingEnemies),
 				new RoomSpecificEnemies(10, 6, E.PresentBomber, //bombers before lab near gun-orb
 					E.PresentBomber),
-				new RoomSpecificEnemies(9, 7, E.XarionBossHand, //Xarions hand
-					E.XarionBossHand),
 				new RoomSpecificEnemies(8, 43, E.PastSnail, //Maw first snail
 					E.PastSnail),
 				new RoomSpecificEnemies(9, 43, E.PresentSnail, //Maw first snail
@@ -237,8 +235,8 @@ namespace TsRandomizer.LevelObjects
 			HardcodedEnemies.TryGetValue(roomKey, out var roomSpecificEnemies);
 
 			foreach (var enemy in enemies.ToArray())
-			{
-				if (enemy.EnemyType == EEnemyTileType.JunkSpawner || enemy.EnemyType == EEnemyTileType.LabAdult)
+			{	
+				if (enemy.EnemyType == EEnemyTileType.JunkSpawner || enemy.EnemyType == EEnemyTileType.LabAdult || enemy.EnemyType == EEnemyTileType.XarionBoss)
 					continue;
 				
 				var type = enemy.GetType();


### PR DESCRIPTION
Fixes bug where the enemy randomizer would replace Xarion's hand with a second Xarion.

While I'm not too familiar, investigating, it seems as though the hand shares a `XarionBoss` type, yet `if (type.IsSubclassOf(BossType))` does not properly ignore it.

This did not affect boss rando, as boss rando enemies are spawned after the enemy rando runs.

There is likely a cleaner way to handle some of these edge cases, such as not replacing an enemy when the source and desired target are the same  (also, there is an existing `EMinionID.XarionHand`, we could possibly have the enemizer exclude any int in the enum of EMinionId and EBossID)

This was tested with all combos of boss and enemy rando on and off.

![image](https://github.com/user-attachments/assets/237c1f7b-41e1-4014-a97f-6b9193f63cd8)
![image](https://github.com/user-attachments/assets/17d46d9c-028b-4798-8079-4e4254b79ffa)
