### PR TITLE
Add Aura Boost to Lightwall Climbs

### DIFF
--- a/TsRandomizer/LevelObjects/LevelObject.cs
+++ b/TsRandomizer/LevelObjects/LevelObject.cs
@@ -159,6 +159,8 @@ namespace TsRandomizer.LevelObjects
 			level.GameSave.AddItem(level, new ItemIdentifier(EInventoryRelicType.Dash));
 			level.GameSave.AddItem(level, new ItemIdentifier(EInventoryRelicType.EssenceOfSpace));
 			level.GameSave.AddItem(level, new ItemIdentifier(EInventoryRelicType.DoubleJump));
+			level.GameSave.AddItem(level, new ItemIdentifier(EInventoryOrbType.Barrier, EOrbSlot.Spell));
+			level.GameSave.AddItem(level, new ItemIdentifier(EInventoryRelicType.WaterMask));
 #endif
 
 			Objects.Clear();

--- a/TsRandomizer/RoomTriggers/Triggers/LightwallClimbBoost.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/LightwallClimbBoost.cs
@@ -1,0 +1,17 @@
+﻿using TsRandomizer.Extensions;
+
+namespace TsRandomizer.RoomTriggers.Triggers
+{
+	[RoomTriggerTrigger(11, 2)] // Post-dynamo room
+	[RoomTriggerTrigger(16, 6)] // Pyramid Shaft
+	class LightwallClimbBoost : RoomTrigger
+	{
+		public override void OnRoomLoad(RoomState roomState)
+		{
+			// Mark the room as boosted aura to help with the climb
+			roomState.Level.AsDynamic().IsOnVilete = true;
+			roomState.Level.MainHero.AsDynamic().IsOnVilete = true;
+		}
+
+	}
+}


### PR DESCRIPTION
Cleaner version of https://github.com/Jarno458/TsRandomizer/pull/154/files 

The change to level object was adding lightwall and water mask to the items given when in debug mode, as both are helpful to have when testing things.