### PR TITLE
Fix Risky Warp Selection

### DIFF
--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -23,6 +23,8 @@ namespace TsRandomizer.Randomisation
 		void SetTeleporterPickupAction(Seed seed)
 		{
 			IEnumerable<TeleporterGate> presentTeleporterGates = PresentTeleporterGates;
+                        if (!seed.Options.RiskyWarps)
+				presentTeleporterGates = presentTeleporterGates.Where(g => g.Safe);
 
 			if (seed.FloodFlags.Lab)
 				presentTeleporterGates = presentTeleporterGates.Where(g => g.Gate != R.GateLabEntrance);


### PR DESCRIPTION
Fixes bug where pyramid keys could select risky present locations with risky flag off

This was already covered in unchained keys