### PR TITLE
Simplify Era

### DIFF
--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -195,7 +195,7 @@ namespace TsRandomizer.Randomisation
 				| (R.GateMilitaryGate & (R.CardE | R.CardB))
 				| militaryFortressToLakeDesolation;
 
-			if ((StartingEra == Era.Past || StartingEra == Era.Pyramid) && SeedOptions.BackToTheFuture) {
+			if (StartingEra != Era.Present && SeedOptions.BackToTheFuture) {
 				LakeDesolationLeft |= R.TimespinnerWheel & R.TimespinnerSpindle;
 				LakeDesolationRight |= R.TimespinnerWheel & R.TimespinnerSpindle;
 			}

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -77,6 +77,7 @@ namespace TsRandomizer.Randomisation
 		protected readonly ItemUnlockingMap UnlockingMap;
 		protected readonly SeedOptions SeedOptions;
 		protected readonly RisingTides FloodsFlags;
+		protected readonly Era StartingEra;
 
 		string areaName;
 
@@ -87,6 +88,7 @@ namespace TsRandomizer.Randomisation
 			UnlockingMap = itemUnlockingMap;
 			SeedOptions = seed.Options;
 			FloodsFlags = seed.FloodFlags;
+			StartingEra = seed.StartingEra;
 
 			SetupGates();
 
@@ -131,7 +133,7 @@ namespace TsRandomizer.Randomisation
 				: R.Free;
 
 			var pastRoutesToRefugeeCamp =
-				(SeedOptions.Inverted && !SeedOptions.PyramidStart)
+				(StartingEra == Era.Past)
 					? R.Free
 					: R.GateRefugeeCamp
 					| R.GateLakeSereneLeft
@@ -167,14 +169,14 @@ namespace TsRandomizer.Randomisation
 				& (
 					SeedOptions.PrismBreak 
 						? R.LaserA & R.LaserI & R.LaserM
-						: (SeedOptions.Inverted && !SeedOptions.PyramidStart ? R.Free : pastRoutesToRefugeeCamp)
+						: (StartingEra == Era.Past ? R.Free : pastRoutesToRefugeeCamp)
 						  & R.TimeStop // Refugee camp -> kill Twins
 						  & (MultipleSmallJumpsOfNpc | ForwardDashDoubleJump) & R.DoubleJump // Refugee camp -> kill Aelana 
 						  & refugeeCampToMaw // Refugee camp -> kill Maw
 				) // militaryLazerGate
 				& (R.CardE | R.CardB);
 
-			LakeDesolationLeft = (!SeedOptions.Inverted && !SeedOptions.PyramidStart)
+			LakeDesolationLeft = (StartingEra == Era.Present)
 				? R.Free
 				: R.GateLakeDesolation
 				  | R.GateKittyBoss
@@ -193,12 +195,12 @@ namespace TsRandomizer.Randomisation
 				| (R.GateMilitaryGate & (R.CardE | R.CardB))
 				| militaryFortressToLakeDesolation;
 
-			if ((SeedOptions.Inverted || SeedOptions.PyramidStart) && SeedOptions.BackToTheFuture) {
+			if ((StartingEra == Era.Past || StartingEra == Era.Pyramid) && SeedOptions.BackToTheFuture) {
 				LakeDesolationLeft |= R.TimespinnerWheel & R.TimespinnerSpindle;
 				LakeDesolationRight |= R.TimespinnerWheel & R.TimespinnerSpindle;
 			}
 
-			RefugeeCamp = (SeedOptions.Inverted && !SeedOptions.PyramidStart)
+			RefugeeCamp = (StartingEra == Era.Past)
 				? R.Free
 				: (
 					R.TimespinnerWheel & R.TimespinnerSpindle
@@ -701,8 +703,8 @@ namespace TsRandomizer.Randomisation
 
 			var levelIdsToAvoid = new List<int>(3) { 1 }; //lake desolation
 			var mawRequirements = R.None;
-			
-			if (!SeedOptions.Inverted && !SeedOptions.PyramidStart)
+	
+			if (StartingEra == Era.Present)
 			{
 				mawRequirements |= R.GateAccessToPast;
 

--- a/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
@@ -150,7 +150,7 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 
 		protected void PlaceStarterProgressionItems(Random random)
 		{
-			if (Seed.StartingEra != Era.Pyramid && (Seed.StartingEra == Era.Past || SeedOptions.StartWithTalaria || Seed.FloodFlags.LakeDesolation)) 
+			if (Seed.StartingEra == Era.Past || (Seed.StartingEra == Era.Present && (SeedOptions.StartWithTalaria || Seed.FloodFlags.LakeDesolation))) 
 				GiveOrbsToMom(random, false);
 			else
 				PlaceStarterProgressionInLakeDesolationItem(random);

--- a/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
@@ -150,7 +150,7 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 
 		protected void PlaceStarterProgressionItems(Random random)
 		{
-			if (!SeedOptions.PyramidStart && (SeedOptions.Inverted || SeedOptions.StartWithTalaria || Seed.FloodFlags.LakeDesolation)) 
+			if (Seed.StartingEra != Era.Pyramid && (Seed.StartingEra == Era.Past || SeedOptions.StartWithTalaria || Seed.FloodFlags.LakeDesolation)) 
 				GiveOrbsToMom(random, false);
 			else
 				PlaceStarterProgressionInLakeDesolationItem(random);
@@ -282,7 +282,7 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 			var levelIdsToAvoid = new List<int>(3) { 1 };
 			var minimalMawRequirements = R.None;
 
-			if (!SeedOptions.Inverted && !SeedOptions.PyramidStart)
+			if (Seed.StartingEra == Era.Present)
 			{
 				minimalMawRequirements |= R.GateAccessToPast;
 

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -31,7 +31,7 @@ namespace TsRandomizer.Randomisation
 
 			var teleporterGates = presentTeleporterGates;
 
-			if (!seed.Options.Inverted || seed.Options.PyramidStart)
+			if (seed.StartingEra != Era.Past)
 			{
 				IEnumerable<TeleporterGate> pastTeleporterGates = PastTeleporterGates;
 				if (!seed.Options.RiskyWarps)

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -23,6 +23,8 @@ namespace TsRandomizer.Randomisation
 		void SetTeleporterPickupAction(Seed seed)
 		{
 			IEnumerable<TeleporterGate> presentTeleporterGates = PresentTeleporterGates;
+			if (!seed.Options.RiskyWarps)
+				presentTeleporterGates = presentTeleporterGates.Where(g => g.Safe);
 
 			if (seed.FloodFlags.Lab)
 				presentTeleporterGates = presentTeleporterGates.Where(g => g.Gate != R.GateLabEntrance);

--- a/TsRandomizer/RoomTriggers/Triggers/Bosses/Genza.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/Bosses/Genza.cs
@@ -33,8 +33,7 @@ namespace TsRandomizer.RoomTriggers.Triggers.Bosses
 					&& level.GameSave.HasRelic(EInventoryRelicType.ScienceKeycardA))
 				RoomTriggerHelper.SpawnItemDropPickup(level, roomState.RoomItemLocation.ItemInfo, 200, 200);
 
-			if (!roomState.Seed.Options.Inverted 
-					&& !roomState.Seed.Options.PyramidStart 
+			if (roomState.Seed.StartingEra == Era.Present
 					&& level.GameSave.HasCutsceneBeenTriggered("Alt3_Teleport"))
 				RoomTriggerHelper.CreateSimpleOneWayWarp(roomState.Level, 16, 12);
 		}

--- a/TsRandomizer/RoomTriggers/Triggers/LibraryRefugeeCampTeleporters.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/LibraryRefugeeCampTeleporters.cs
@@ -13,7 +13,7 @@ namespace TsRandomizer.RoomTriggers.Triggers
 
 			if (roomState.Level.GameSave.DataKeyBools.ContainsKey("HasUsedCityTS") 
 			    && (
-					!roomState.Seed.Options.Inverted
+					roomState.Seed.StartingEra != Era.Past
 					|| (
 						roomState.Seed.Options.BackToTheFuture
 					    && roomState.Level.GameSave.HasRelicEnabled(EInventoryRelicType.TimespinnerWheel)

--- a/TsRandomizer/RoomTriggers/Triggers/PastTimespinnerFreeFallCutScene.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/PastTimespinnerFreeFallCutScene.cs
@@ -5,7 +5,7 @@
 	{
 		public override void OnRoomLoad(RoomState roomState)
 		{
-			if (!roomState.Seed.Options.Inverted) return;
+			if (roomState.Seed.StartingEra != Era.Past) return;
 				RoomTriggerHelper.CreateAndCallCutScene(roomState, "Forest0_Warp");
 		}
 	}

--- a/TsRandomizer/Seed.cs
+++ b/TsRandomizer/Seed.cs
@@ -3,6 +3,12 @@ using System.Globalization;
 
 namespace TsRandomizer
 {
+	public enum Era
+	{
+		Past,
+		Present,
+		Pyramid
+	}
 	struct Seed
 	{
 		public const int Length = 8 + SeedOptions.Length;
@@ -10,6 +16,7 @@ namespace TsRandomizer
 		public readonly uint Id;
 		public readonly SeedOptions Options;
 		public readonly RisingTides FloodFlags;
+		public readonly Era StartingEra;
 
 		public static Seed Zero = new Seed(0U, SeedOptions.None);
 
@@ -18,6 +25,11 @@ namespace TsRandomizer
 			Id = id;
 			Options = options;
 			FloodFlags = floodFlags ?? new RisingTides(id, options);
+			StartingEra = Era.Present;
+			if (options.PyramidStart)
+				StartingEra = Era.Pyramid;
+			else if (options.Inverted)
+				StartingEra = Era.Past;
 		}
 
 		public static Seed GenerateRandom(SeedOptions options, Random random)


### PR DESCRIPTION
This sets an enum in the seed option for the starting era to reduce the complexity of our conditionals (pyramid overwriting inverted)