### PR TITLE
New seed option: Gate Keep

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -58,7 +58,7 @@ In order to use the randomizer on a steam deck, you will have to install the ran
 * Anywhere, ` (tilde) will open the console. the console can be used to activate some command see /help for a list of available commands, if you are connected to an archipelago server any text typed in the console is sent to the server, giving you access to server commands
 
 # Routing Changes
-* The drawbridge is now open by default, and doesn't require you to visit the Demon Twins in Lake Serene.
+* The drawbridge is now open by default, and doesn't require you to visit the Demon Twins in Lake Serene. When using the "Gate Keep" flag, the castle drawbridge starts raised and can be lowered via item, although logic will consider the raised drawbridge to be traversable with Lightwall or Celestial Sash.
 * Amadeus' Laboratory now requires keycard B to open
 * To prevent players from getting stuck in the past when items are still available in the present, the transition room next to the refugee camp can now be used to freely travel back and forth between past and present
 * When you obtain the twin pyramid key, a random transition room is unlocked that could open new routing opportunities. In the "Unchained Keys" flag, these bonus warps are found as items.

--- a/TsRandomizer.ItemTracker/TrackerRenderer.cs
+++ b/TsRandomizer.ItemTracker/TrackerRenderer.cs
@@ -92,6 +92,7 @@ namespace TsRandomizerItemTracker
 				DrawPinkSource(spriteBatch, state);
 				DrawLaserAccess(spriteBatch, state);
 				DrawLabAccess(spriteBatch, state);
+				DrawItem(spriteBatch, state.DrawbridgeKey, 236, Color.White);
 			}
 		}
 
@@ -176,6 +177,11 @@ namespace TsRandomizerItemTracker
 
 		void DrawItem(SpriteBatch spriteBatch, bool obtained, ItemIdentifier itemInfo, Color color)
 		{
+			DrawItem(spriteBatch, obtained, GetAnimationIndex(itemInfo), color);
+		}
+
+		void DrawItem(SpriteBatch spriteBatch, bool obtained, int animationIndex, Color color)
+		{
 			if (xIndex >= columnCount)
 			{
 				xIndex = 0;
@@ -185,7 +191,7 @@ namespace TsRandomizerItemTracker
 			var position = new Point(xIndex++ * IconSize, yIndex * IconSize);
 
 			DrawItem(spriteBatch, new Rectangle(position.X, position.Y, IconSize, IconSize), 
-                obtained, GetAnimationIndex(itemInfo), color);
+                obtained, animationIndex, color);
 		}
 
         void DrawSubItem(SpriteBatch spriteBatch, bool obtained, ItemIdentifier itemInfo, 

--- a/TsRandomizer/Archipelago/ItemMap.cs
+++ b/TsRandomizer/Archipelago/ItemMap.cs
@@ -213,8 +213,9 @@ namespace TsRandomizer.Archipelago
 				{1337195, CustomItem.GetIdentifier(CustomItemType.LabAccessExperiment)},
 				{1337196, CustomItem.GetIdentifier(CustomItemType.LabAccessResearch)},
 				{1337197, CustomItem.GetIdentifier(CustomItemType.LabAccessDynamo)},
+				{1337198, CustomItem.GetIdentifier(CustomItemType.DrawbridgeKey)},
 
-				// 1337198 - 1337248 Reserved for future use
+				// 1337199 - 1337248 Reserved for future use
 
 				{1337249, new ItemIdentifier(EItemType.MaxSand)}
 			};

--- a/TsRandomizer/IntermediateObjects/CustomItems/CustomItem.cs
+++ b/TsRandomizer/IntermediateObjects/CustomItems/CustomItem.cs
@@ -28,7 +28,8 @@ namespace TsRandomizer.IntermediateObjects.CustomItems
 		LabAccessGenza,
 		LabAccessExperiment,
 		LabAccessResearch,
-		LabAccessDynamo
+		LabAccessDynamo,
+		DrawbridgeKey
 	}
 
 	// consider beacons as starting items

--- a/TsRandomizer/IntermediateObjects/CustomItems/DrawbridgeKey.cs
+++ b/TsRandomizer/IntermediateObjects/CustomItems/DrawbridgeKey.cs
@@ -1,0 +1,25 @@
+﻿using Timespinner.GameAbstractions.Gameplay;
+using Timespinner.GameAbstractions.Inventory;
+using TsRandomizer.Randomisation;
+using TsRandomizer.Screens;
+
+namespace TsRandomizer.IntermediateObjects.CustomItems
+{
+	class DrawbridgeKey : CustomItem
+	{
+		public override int AnimationIndex => 236;
+
+		protected override bool RemoveFromInventory => false;
+
+		public DrawbridgeKey(ItemUnlockingMap unlockingMap) : base(unlockingMap, CustomItemType.DrawbridgeKey)
+		{
+			SetDescription("Holders of this key may approach the castle to find the drawbridge lowered.", null);
+		}
+
+		internal override void OnPickup(Level level, GameplayScreen gameplayScreen)
+		{
+			base.OnPickup(level, gameplayScreen);
+			level.JukeBox.PlayCue(Timespinner.GameAbstractions.ESFX.FoleyDrawbridgeLockProper);
+		}
+	}
+}

--- a/TsRandomizer/ItemTracker/ItemTrackerState.cs
+++ b/TsRandomizer/ItemTracker/ItemTrackerState.cs
@@ -54,6 +54,7 @@ namespace TsRandomizer.ItemTracker
 		public bool LabDynamo;
 		public bool LabExperiment;
 		public bool LabResearch;
+		public bool DrawbridgeKey;
 
 		internal static ItemTrackerState FromItemLocationMap(IEnumerable<ItemLocation> itemLocations)
 		{
@@ -122,6 +123,7 @@ namespace TsRandomizer.ItemTracker
 			{CustomItem.GetIdentifier(CustomItemType.LabAccessDynamo), s => s.LabDynamo},
 			{CustomItem.GetIdentifier(CustomItemType.LabAccessExperiment), s => s.LabExperiment},
 			{CustomItem.GetIdentifier(CustomItemType.LabAccessResearch), s => s.LabResearch},
+			{CustomItem.GetIdentifier(CustomItemType.DrawbridgeKey), s => s.DrawbridgeKey},
 		};
 
 		static void SetMemberForItem(ItemTrackerState trackerState, ItemIdentifier itemInfo)

--- a/TsRandomizer/LevelObjects/Other/CurtainDrawbridge.cs
+++ b/TsRandomizer/LevelObjects/Other/CurtainDrawbridge.cs
@@ -1,5 +1,7 @@
 ﻿using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.Extensions;
 using TsRandomizer.IntermediateObjects;
+using TsRandomizer.IntermediateObjects.CustomItems;
 using TsRandomizer.Screens;
 using TsRandomizer.Settings;
 
@@ -15,7 +17,7 @@ namespace TsRandomizer.LevelObjects.Other
 
 		protected override void Initialize(Seed seed, SettingCollection settings)
 		{
-			if (!(!LevelReflected.GetLevelSaveBool("HasWinchBeenUsed") ? false : LevelReflected.GetLevelSaveBool("IsDrawbridgeRaised")))
+			if (!(!LevelReflected.GetLevelSaveBool("HasWinchBeenUsed") ? seed.Options.GateKeep && !Level.GameSave.HasItem(CustomItem.GetIdentifier(CustomItemType.DrawbridgeKey)) : LevelReflected.GetLevelSaveBool("IsDrawbridgeRaised")))
 			{
 				Dynamic._isEngineerDead = true;
 				Dynamic._isRaising = true;

--- a/TsRandomizer/LevelObjects/Other/EnvPrefabCurtainWinch.cs
+++ b/TsRandomizer/LevelObjects/Other/EnvPrefabCurtainWinch.cs
@@ -1,5 +1,7 @@
 ﻿using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.Extensions;
 using TsRandomizer.IntermediateObjects;
+using TsRandomizer.IntermediateObjects.CustomItems;
 using TsRandomizer.Screens;
 using TsRandomizer.Settings;
 
@@ -16,7 +18,7 @@ namespace TsRandomizer.LevelObjects.Other
 		protected override void Initialize(Seed seed, SettingCollection settings)
 		{
 			Dynamic._isDrawbridgeUp = !LevelReflected.GetLevelSaveBool("HasWinchBeenUsed") 
-				? false 
+				? seed.Options.GateKeep && !Level.GameSave.HasItem(CustomItem.GetIdentifier(CustomItemType.DrawbridgeKey))
 				: LevelReflected.GetLevelSaveBool("IsDrawbridgeRaised");
 			Dynamic._isRotatingClockwise = Dynamic._isDrawbridgeUp;
 		}

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -224,7 +224,7 @@ namespace TsRandomizer.Randomisation
 			CavesOfBanishment = (LowerLakeSirine & (FloodsFlags.DryLakeSerene ? R.DoubleJump : R.Free)) | R.GateCavesOfBanishment | (R.GateMaw & R.DoubleJump);
 			CavesOfBanishmentFlooded = CavesOfBanishment & NeedSwimming(FloodsFlags.Maw);
 			UpperCavesOfBanishment = RefugeeCamp;
-			CastleRamparts = RefugeeCamp;
+			CastleRamparts = (SeedOptions.GateKeep) ? RefugeeCamp & (R.DrawbridgeKey | R.UpwardDash | R.GateCastleKeep) : RefugeeCamp;
 			CastleKeep = CastleRamparts;
 			CastleBasement = CastleKeep & NeedSwimming(FloodsFlags.Basement);
 			RoyalTower = (CastleKeep & R.DoubleJump) | R.GateRoyalTowers;

--- a/TsRandomizer/Randomisation/ItemUnlockingMap.cs
+++ b/TsRandomizer/Randomisation/ItemUnlockingMap.cs
@@ -195,6 +195,10 @@ namespace TsRandomizer.Randomisation
 				UnlockingSpecifications.Add(new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.LabAccessExperiment), R.LabExperiment));
 				UnlockingSpecifications.Add(new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.LabAccessResearch), R.LabResearch));
 			}
+			if (seed.Options.GateKeep)
+			{
+				UnlockingSpecifications.Add(new UnlockingSpecification(CustomItem.GetIdentifier(CustomItemType.DrawbridgeKey), R.DrawbridgeKey));
+			}
 		}
 
 		void MakeKeyCardUnlocksCardSpecific()

--- a/TsRandomizer/Randomisation/Requirement.cs
+++ b/TsRandomizer/Randomisation/Requirement.cs
@@ -44,6 +44,7 @@ namespace TsRandomizer.Randomisation
 		public static readonly Requirement LabDynamo = 1UL << 35;
 		public static readonly Requirement LabExperiment = 1UL << 36;
 		public static readonly Requirement LabResearch = 1UL << 37;
+		public static readonly Requirement DrawbridgeKey = 1UL << 38;
 
 		public static readonly Requirement GateRefugeeCamp = 1UL << 42;
 		public static readonly Requirement GateSealedCaves = 1UL << 43;

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -32,6 +32,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 23, new SeedOptionInfo { Name = "Lock Key Amadeus", Description = "Lasers in Amadeus' Laboratory are disabled via items, rather than by de-powering the lab. Experiments will spawn in the lab." } },
 			{ 1 << 24, new SeedOptionInfo { Name = "Risky Warps", Description = "Expanded free-warp eligible locations, including Azure Queen, Xarion, Amadeus' Laboratory, and Emperor's Tower." } },
 			{ 1 << 25, new SeedOptionInfo { Name = "Pyramid Start", Description = "Start in ???. Takes priority over Inverted. Additional chests in Dark Forest and Pyramid. Sandman door behaves as it does in Enter Sandman." } },
+			{ 1 << 26, new SeedOptionInfo { Name = "Gate Keep", Description = "The castle drawbridge starts raised, and can be lowered via item." } },
 		};
 
 		public SeedOptionsCollection(SeedOptions seedOptions)

--- a/TsRandomizer/SeedOptions.cs
+++ b/TsRandomizer/SeedOptions.cs
@@ -36,6 +36,7 @@ namespace TsRandomizer
 		public bool LockKeyAmadeus => (Flags & 1 << 23) > 0;
 		public bool RiskyWarps => (Flags & 1 << 24) > 0;
 		public bool PyramidStart => (Flags & 1 << 25) > 0;
+		public bool GateKeep => (Flags & 1 << 26) > 0;
 
 		public SeedOptions(uint flags)
 		{
@@ -75,6 +76,7 @@ namespace TsRandomizer
 				{"LockKeyAmadeus", 1U << 23},
 				{"RiskyWarps", 1U << 24},
 				{"PyramidStart", 1U << 25},
+				{"GateKeep", 1U << 26},
 			};
 
 			foreach (var kvp in stringToFlagMapping)

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -154,6 +154,7 @@
     <Compile Include="IntermediateObjects\CustomItems\StatusTrap.cs" />
     <Compile Include="IntermediateObjects\CustomItems\Trap.cs" />
     <Compile Include="IntermediateObjects\CustomItems\LaserAccessKey.cs" />
+    <Compile Include="IntermediateObjects\CustomItems\DrawbridgeKey.cs" />
     <Compile Include="IntermediateObjects\CustomItems\UnchainedKey.cs" />
     <Compile Include="IntermediateObjects\ProgressiveItemProvider.cs" />
     <Compile Include="LevelObjects\CollisionDetectionEvent.cs" />


### PR DESCRIPTION
Name subject to change (the other option I considered for it was "The Gate Isn't Down").

When using the "Gate Keep" flag, the castle drawbridge starts raised and can be lowered via item, although logic will consider the raised drawbridge to be traversable with Lightwall or Celestial Sash.

This is mainly prompted by my playing one too many inverted seeds with a lengthy search for progression over the available starting checks; I find with some testing that the amount of searching decreases considerably when half of the castle isn't available from the get-go.