### PR TITLE
Fix Risky Warp Softlock Exits

### DIFF
--- a/TsRandomizer/LevelObjects/Other/GlowingFloorEvent.cs
+++ b/TsRandomizer/LevelObjects/Other/GlowingFloorEvent.cs
@@ -69,7 +69,7 @@ namespace TsRandomizer.LevelObjects.Other
 		protected override void OnUpdate()
 		{
 			Roomkey room = new Roomkey(Dynamic.Level.ID, Dynamic.Level.RoomID);
-			if ((room.LevelId != 16 && room.LevelId != 7 && room.LevelId != 11) || (room.LevelId == 11 && room.RoomId == 21))
+			if ((room.LevelId != 16 && room.LevelId != 7 && room.LevelId != 11 && room.LevelId != 10) || (room.LevelId == 11 && room.RoomId == 21))
 				return;
 			if (teleportTriggered)
 				return;

--- a/TsRandomizer/RoomTriggers/Triggers/LabSoftlockExits.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/LabSoftlockExits.cs
@@ -12,7 +12,11 @@ namespace TsRandomizer.RoomTriggers.Triggers
 			if (!roomState.Seed.Options.RiskyWarps)
 				return;
 			// Only spawns if you are past the laser but it's still on (i.e. coming from Dad's Tower warp)
-			if (roomState.Level.RoomID == 16 && !roomState.Level.GameSave.HasItem(CustomItem.GetIdentifier(CustomItemType.LabAccessGenza)))
+			if (roomState.Level.RoomID == 16 && (
+				// 11_LabPower true = power off
+				!roomState.Level.GameSave.GetSaveBool("11_LabPower")
+				|| (roomState.Seed.Options.LockKeyAmadeus && !roomState.Level.GameSave.HasItem(CustomItem.GetIdentifier(CustomItemType.LabAccessGenza)))
+			))
 				RoomTriggerHelper.SpawnGlowingFloor(roomState.Level, new Point(900, 300));
 		}
 

--- a/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarGyreWarp.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarGyreWarp.cs
@@ -13,6 +13,8 @@ namespace TsRandomizer.RoomTriggers.Triggers
 					// Military Hangar crash site to Gyre
 					RoomTriggerHelper.SpawnGyreWarp(roomState.Level, 340, 180);
 			}
+			else if (roomState.Seed.Options.RiskyWarps)
+				RoomTriggerHelper.SpawnGlowingFloor(roomState.Level, new Point(360, 120));
 		}
 	}
 }

--- a/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarGyreWarp.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarGyreWarp.cs
@@ -13,9 +13,6 @@ namespace TsRandomizer.RoomTriggers.Triggers
 					// Military Hangar crash site to Gyre
 					RoomTriggerHelper.SpawnGyreWarp(roomState.Level, 340, 180);
 			}
-			else if (roomState.Seed.Options.RiskyWarps)
-				RoomTriggerHelper.SpawnGlowingFloor(roomState.Level, new Point(360, 120));
-			
 		}
 	}
 }

--- a/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarWarpRoom.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarWarpRoom.cs
@@ -1,7 +1,8 @@
 ﻿using TsRandomizer.Randomisation;
 namespace TsRandomizer.RoomTriggers.Triggers
 {
-	[RoomTriggerTrigger(10, 12)]
+	[RoomTriggerTrigger(10, 12),
+	 RoomTriggerTrigger(10, 1)]
 	class MilitaryHangarWarpRoom : RoomTrigger
 	{
 		public override void OnRoomLoad(RoomState roomState)


### PR DESCRIPTION
The lab softlock exit previously showed up if you had Risky Warps on, regardless. 

It now requires the laser to actually be up (either via power being on, or you being in Lock Key Amadeus and lacking the requisite key)

----
Two fixes for the hangar softlock exit
- Allows hangar to be a valid level where floors are overwritten
- Entering hangar entrance from the right will refresh boss save flags