### PR TITLE
Allow building on Linux

### DIFF
--- a/TsRandomizer.ItemTracker/TsRandomizer.ItemTracker.csproj
+++ b/TsRandomizer.ItemTracker/TsRandomizer.ItemTracker.csproj
@@ -101,6 +101,7 @@
     <Reference Include="FNA, Version=19.5.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Timespinner\FNA.dll</HintPath>
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Timespinner/FNA.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -110,12 +111,14 @@
     <Reference Include="Timespinner, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Timespinner\Timespinner.exe</HintPath>
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Timespinner/Timespinner.exe</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="TsRandomizer, Version=1.26.5.0, Culture=neutral, processorArchitecture=x86">
+    <!-- <Reference Include="TsRandomizer, Version=1.26.5.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Timespinner\TsRandomizer.exe</HintPath>
-    </Reference>
+    </Reference> -->
+    <ProjectReference Include="..\TsRandomizer\TsRandomizer.csproj"></ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BackgroundProvider.cs" />

--- a/TsRandomizer.ItemTracker/TsRandomizer.ItemTracker.csproj
+++ b/TsRandomizer.ItemTracker/TsRandomizer.ItemTracker.csproj
@@ -100,8 +100,8 @@
   <ItemGroup>
     <Reference Include="FNA, Version=19.5.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Timespinner\FNA.dll</HintPath>
-      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Timespinner/FNA.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Timespinner\FNA.dll')">C:\Program Files (x86)\Steam\steamapps\common\Timespinner\FNA.dll</HintPath>
+      <HintPath Condition="Exists('$(HOME)/.local/share/Steam/steamapps/common/Timespinner/FNA.dll')">$(HOME)/.local/share/Steam/steamapps/common/Timespinner/FNA.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -110,8 +110,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="Timespinner, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Timespinner\Timespinner.exe</HintPath>
-      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Timespinner/Timespinner.exe</HintPath>
+      <HintPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Timespinner\Timespinner.exe')">C:\Program Files (x86)\Steam\steamapps\common\Timespinner\Timespinner.exe</HintPath>
+      <HintPath Condition="Exists('$(HOME)/.local/share/Steam/steamapps/common/Timespinner/Timespinner.exe')">$(HOME)/.local/share/Steam/steamapps/common/Timespinner/Timespinner.exe</HintPath>
       <Private>False</Private>
     </Reference>
     <!-- <Reference Include="TsRandomizer, Version=1.26.5.0, Culture=neutral, processorArchitecture=x86">

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -106,8 +106,8 @@
     </Reference>
     <Reference Include="FNA">
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Timespinner\FNA.dll</HintPath>
-      <HintPath>~/.local/share/Steam/steamapps/common/Timespinner/FNA.dll</HintPath>
       <HintPath>..\..\..\TestVersions\DRMFreeVersion\FNA.dll</HintPath>
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Timespinner/FNA.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -121,6 +121,7 @@
     </Reference>
     <Reference Include="Timespinner">
       <HintPath>..\..\..\TestVersions\DRMFreeVersion\Timespinner.exe</HintPath>
+      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Timespinner/Timespinner.exe</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -105,9 +105,9 @@
       <HintPath>..\packages\Archipelago.MultiClient.Net.6.5.0\lib\net45\Archipelago.MultiClient.Net.dll</HintPath>
     </Reference>
     <Reference Include="FNA">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Timespinner\FNA.dll</HintPath>
-      <HintPath>..\..\..\TestVersions\DRMFreeVersion\FNA.dll</HintPath>
-      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Timespinner/FNA.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Timespinner\FNA.dll')">C:\Program Files (x86)\Steam\steamapps\common\Timespinner\FNA.dll</HintPath>
+      <HintPath Condition="Exists('..\..\..\TestVersions\DRMFreeVersion\FNA.dll')">..\..\..\TestVersions\DRMFreeVersion\FNA.dll</HintPath>
+      <HintPath Condition="Exists('$(HOME)/.local/share/Steam/steamapps/common/Timespinner/FNA.dll')">$(HOME)/.local/share/Steam/steamapps/common/Timespinner/FNA.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -120,8 +120,8 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Timespinner">
-      <HintPath>..\..\..\TestVersions\DRMFreeVersion\Timespinner.exe</HintPath>
-      <HintPath>$(HOME)/.local/share/Steam/steamapps/common/Timespinner/Timespinner.exe</HintPath>
+      <HintPath Condition="Exists('..\..\..\TestVersions\DRMFreeVersion\Timespinner.exe')">..\..\..\TestVersions\DRMFreeVersion\Timespinner.exe</HintPath>
+      <HintPath Condition="Exists('$(HOME)/.local/share/Steam/steamapps/common/Timespinner/Timespinner.exe')">$(HOME)/.local/share/Steam/steamapps/common/Timespinner/Timespinner.exe</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Some changes that should allow for building on Linux

This is currently not fully complete, here's a list of what still needs to be done:
- [ ] Change output dirs to something that works across multiple platforms
- [ ] Maybe make outputting to the Timespinner dir based on a new build configuration option instead of on a Release build?
- [ ] Test that I didn't break anything for building on Windows

I have not made any changes to TsRandomizer.SeedGeneratah, as I have been told that it is "broken and fallen into dispair"