### PR TITLE
Don't always show the drawbridge key in the item tracker

### DIFF
--- a/TsRandomizer.ItemTracker/TrackerRenderer.cs
+++ b/TsRandomizer.ItemTracker/TrackerRenderer.cs
@@ -74,8 +74,6 @@ namespace TsRandomizerItemTracker
 
 		public void Draw(SpriteBatch spriteBatch, ItemTrackerState state)
         {
-            state.DrawbridgeKey = true;
-
 
             ResetPosition();
 


### PR DESCRIPTION
Looks like this was accidentally left in in 9cd7c2814440f8dfc93e2a1b3ffcd9ae0792f7de.