### PR TITLE
New flag: Royal Roadblock

### DIFF
--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -227,7 +227,7 @@ namespace TsRandomizer.Randomisation
 			CastleRamparts = (SeedOptions.GateKeep) ? RefugeeCamp & (R.DrawbridgeKey | R.UpwardDash | R.GateCastleKeep) : RefugeeCamp;
 			CastleKeep = CastleRamparts;
 			CastleBasement = CastleKeep & NeedSwimming(FloodsFlags.Basement);
-			RoyalTower = (CastleKeep & R.DoubleJump) | R.GateRoyalTowers;
+			RoyalTower = (CastleKeep & R.DoubleJump & (SeedOptions.GateKeep ? R.PinkOrb : R.Free)) | R.GateRoyalTowers;
 			MidRoyalTower = RoyalTower & (MultipleSmallJumpsOfNpc | ForwardDashDoubleJump);
 			UpperRoyalTower = MidRoyalTower & R.DoubleJump;
 			KillMaw = CavesOfBanishmentFlooded & MawGasMask;

--- a/TsRandomizer/RoomTriggers/Triggers/RoyalTowersDoor.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/RoyalTowersDoor.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Timespinner.GameAbstractions.GameObjects;
+using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.Extensions;
+using TsRandomizer.IntermediateObjects;
+
+namespace TsRandomizer.RoomTriggers.Triggers
+{
+	[RoomTriggerTrigger(5, 29)]
+	class RoyalTowersDoor : RoomTrigger
+	{
+		static readonly Type TransitionDoorEventType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.Doors.TransitionDoorEvent");
+		public override void OnRoomLoad(RoomState roomState)
+		{
+                        if (!roomState.Seed.Options.RoyalRoadblock)
+                                return;
+
+			var transitionDoor = ((Dictionary<int, GameEvent>)roomState.Level.AsDynamic()._levelEvents).Values
+				.FirstOrDefault(obj => obj.GetType() == TransitionDoorEventType);
+			var dynamicDoor = transitionDoor.AsDynamic();
+			dynamicDoor._isRoyalDoor = true;
+			dynamicDoor._baseGemGlowColor = new Color(255, 200, 219, 255);
+			var dynamicMainGem = ((Appendage)dynamicDoor._mainGem).AsDynamic();
+                        var mainGemFrameSource = dynamicMainGem._frameSource;
+			mainGemFrameSource.X = 96;
+			mainGemFrameSource.Y = 49;
+			dynamicMainGem._frameSource = mainGemFrameSource;
+                        var gems = dynamicDoor._gems;
+                        foreach (var gem in gems) {
+			    var dynamicGem = ((Appendage)gem).AsDynamic();
+			    var gemFrameSource = dynamicGem._frameSource;
+			    gemFrameSource.X = 111;
+			    gemFrameSource.Y = 66;
+			    dynamicGem._frameSource = gemFrameSource;
+                        }
+		}
+	}
+}

--- a/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
+++ b/TsRandomizer/Screens/SeedSelection/SeedOptionsCollection.cs
@@ -33,6 +33,7 @@ namespace TsRandomizer.Screens.SeedSelection
 			{ 1 << 24, new SeedOptionInfo { Name = "Risky Warps", Description = "Expanded free-warp eligible locations, including Azure Queen, Xarion, Amadeus' Laboratory, and Emperor's Tower." } },
 			{ 1 << 25, new SeedOptionInfo { Name = "Pyramid Start", Description = "Start in ???. Takes priority over Inverted. Additional chests in Dark Forest and Pyramid. Sandman door behaves as it does in Enter Sandman." } },
 			{ 1 << 26, new SeedOptionInfo { Name = "Gate Keep", Description = "The castle drawbridge starts raised, and can be lowered via item." } },
+			{ 1 << 27, new SeedOptionInfo { Name = "Royal Roadblock", Description = "The Royal Towers entrance door requires a royal orb (Plasma Orb, Plasma Geyser, or Royal Ring) to enter." } },
 		};
 
 		public SeedOptionsCollection(SeedOptions seedOptions)

--- a/TsRandomizer/SeedOptions.cs
+++ b/TsRandomizer/SeedOptions.cs
@@ -38,6 +38,7 @@ namespace TsRandomizer
 		public bool RiskyWarps => (Flags & 1 << 24) > 0;
 		public bool PyramidStart => (Flags & 1 << 25) > 0;
 		public bool GateKeep => (Flags & 1 << 26) > 0;
+		public bool RoyalRoadblock => (Flags & 1 << 27) > 0;
 
 		public SeedOptions(uint flags)
 		{
@@ -78,6 +79,7 @@ namespace TsRandomizer
 				{"RiskyWarps", 1U << 24},
 				{"PyramidStart", 1U << 25},
 				{"GateKeep", 1U << 26},
+				{"RoyalRoadblock", 1U << 27},
 			};
 
 			foreach (var kvp in stringToFlagMapping)

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -220,6 +220,7 @@
     <Compile Include="RoomTriggers\Triggers\PyramidStartBonusGyre.cs" />
     <Compile Include="RoomTriggers\Triggers\PyramidStartBonusRubble.cs" />
     <Compile Include="RoomTriggers\Triggers\RisingTides.cs" />
+    <Compile Include="RoomTriggers\Triggers\RoyalTowersDoor.cs" />
     <Compile Include="RoomTriggers\Triggers\DadsPedistal.cs" />
     <Compile Include="RoomTriggers\Triggers\Bosses\Genza.cs" />
     <Compile Include="RoomTriggers\Triggers\Bosses\GoldenIdol.cs" />


### PR DESCRIPTION
Locks Royal Tower behind a royal orb (Plasma Orb and its derivatives), as with the royal bedroom.

I'm not completely convinced of the name, but I haven't been able to think of anything better.

The idea for this came about from some gameplay experiences while testing Gate Keep, where access to the castle via Lightwall or Sash still presents the problem of still having essentially the entirety of the castle to clear. There's already precedent for having the royal orbs lock a door, so this seems to me to be a reasonable way to leverage an existing concept to provide an opportunity for breaking down the castle into more manageable chunks.

(I'm still not completely sold on the idea myself, but I think it's at least worth presenting now that it's implemented.)