### PR TITLE
Spider traps

### DIFF
--- a/TsRandomizer/Extensions/SettingsExtensions.cs
+++ b/TsRandomizer/Extensions/SettingsExtensions.cs
@@ -46,6 +46,7 @@ namespace TsRandomizer.Extensions
 			settings.NeurotoxinTrap.Value = true;
 			settings.ChaosTrap.Value = true;
 			settings.ThrowStunTrap.Value = true;
+			settings.SpiderTrap.Value = true;
 
 			settings.NoSaveStatues.Value = false; //not voted
 

--- a/TsRandomizer/IntermediateObjects/CustomItems/CustomItem.cs
+++ b/TsRandomizer/IntermediateObjects/CustomItems/CustomItem.cs
@@ -29,7 +29,8 @@ namespace TsRandomizer.IntermediateObjects.CustomItems
 		LabAccessExperiment,
 		LabAccessResearch,
 		LabAccessDynamo,
-		DrawbridgeKey
+		DrawbridgeKey,
+		SpiderTrap
 	}
 
 	// consider beacons as starting items

--- a/TsRandomizer/IntermediateObjects/CustomItems/SpiderTrap.cs
+++ b/TsRandomizer/IntermediateObjects/CustomItems/SpiderTrap.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using Timespinner.Core.Specifications;
+using Timespinner.GameAbstractions.Gameplay;
+using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.Extensions;
+using TsRandomizer.Randomisation;
+using TsRandomizer.Screens;
+
+namespace TsRandomizer.IntermediateObjects.CustomItems
+{
+	class SpiderTrap : Trap
+	{
+		static readonly Type LabSpiderType = TimeSpinnerType.Get("Timespinner.GameAbstractions.GameObjects.LabSpider");
+
+		public SpiderTrap(ItemUnlockingMap unlockingMap) : base(unlockingMap, CustomItemType.SpiderTrap) {}
+
+		internal override void OnPickup(Level level, GameplayScreen gameplayScreen)
+		{
+			base.OnPickup(level, gameplayScreen);
+
+			var enemyTile = new ObjectTileSpecification {
+				Category = EObjectTileCategory.Enemy,
+				Layer = ETileLayerType.Objects,
+				ObjectID = (int)EEnemyTileType.FleshSpider,
+				Argument = 1
+			};
+
+			var lunaisPos = level.MainHero.LastPosition;
+			var sprite = level.GCM.SpLabSpider;
+
+			var rightWall = level.FindFirstSolidTileInDirection(new Point(lunaisPos.X, lunaisPos.Y - 16), EDirection.East);
+			var rightX = (rightWall == null) ? lunaisPos.X + 112 : Math.Min((rightWall.DictKey.X - 1) * 16, lunaisPos.X + 112);
+
+			Monster enemy = ((Monster) LabSpiderType.CreateInstance(false, new Point(rightX, lunaisPos.Y - 16), level, sprite, -1, enemyTile));
+
+			// scale down to base spider values
+			enemy.ScaleTo(16, 20, 20, 4);
+			enemy.AsDynamic()._isAggroed = true;
+			level.AsDynamic().RequestAddObject(enemy);
+
+			var leftWall = level.FindFirstSolidTileInDirection(new Point(lunaisPos.X, lunaisPos.Y - 16), EDirection.West);
+			var leftX = (leftWall == null) ? lunaisPos.X - 112 : Math.Max((leftWall.DictKey.X + 1) * 16, lunaisPos.X - 112);
+			
+			enemy = ((Monster) LabSpiderType.CreateInstance(false, new Point(leftX, lunaisPos.Y - 16), level, sprite, -1, enemyTile));
+
+			enemy.ScaleTo(16, 20, 20, 4);
+			enemy.AsDynamic()._isAggroed = true;
+			level.AsDynamic().RequestAddObject(enemy);
+		}
+	}
+}

--- a/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
+++ b/TsRandomizer/Randomisation/ItemPlacers/FullRandomItemLocationRandomizer.cs
@@ -102,6 +102,8 @@ namespace TsRandomizer.Randomisation.ItemPlacers
 				traps.Add(itemInfoProvider.Get(CustomItem.GetIdentifier(CustomItemType.BeeTrap)));
 			if (settings.ThrowStunTrap.Value)
 				traps.Add(itemInfoProvider.Get(CustomItem.GetIdentifier(CustomItemType.ThrowStunTrap)));
+			if (settings.SpiderTrap.Value)
+				traps.Add(itemInfoProvider.Get(CustomItem.GetIdentifier(CustomItemType.SpiderTrap)));
 		}
 
 		public override ItemLocationMap GenerateItemLocationMap(bool isProgressionOnly)

--- a/TsRandomizer/Settings/GameSettingsLoader.cs
+++ b/TsRandomizer/Settings/GameSettingsLoader.cs
@@ -348,6 +348,7 @@ namespace TsRandomizer.Settings
 				settings.NeurotoxinTrap.Value = traps.Contains("Neurotoxin Trap");
 				settings.BeeTrap.Value = traps.Contains("Bee Trap");
 				settings.ThrowStunTrap.Value = traps.Contains("Throw Stun Trap");
+				settings.SpiderTrap.Value = traps.Contains("Spider Trap");
 			}
 
 			if (slotData.TryGetValue("EnableMapFromStart", out var enableMapFromStart))

--- a/TsRandomizer/Settings/SettingCollection.cs
+++ b/TsRandomizer/Settings/SettingCollection.cs
@@ -20,7 +20,8 @@ namespace TsRandomizer.Settings
 				}},
 			new GameSettingCategoryInfo { Name = "Traps", Description = "Toggles traps available via the Trapped Chests flag.",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
-					s => s.SparrowTrap, s => s.NeurotoxinTrap, s => s.ChaosTrap, s => s.PoisonTrap, s => s.BeeTrap, s => s.ThrowStunTrap
+					s => s.SparrowTrap, s => s.NeurotoxinTrap, s => s.ChaosTrap, s => s.PoisonTrap, s => s.BeeTrap, s => s.ThrowStunTrap,
+					s => s.SpiderTrap
 				}},
 			new GameSettingCategoryInfo { Name = "Minimap", Description = "Settings related to minimap colors.",
 				SettingsPerCategory = new List<Func<SettingCollection, GameSetting>> {
@@ -128,6 +129,9 @@ namespace TsRandomizer.Settings
 
 		public OnOffGameSetting ThrowStunTrap = new OnOffGameSetting("Throw",
 			"Traps can cause Lunais to go flying.", true);
+
+		public OnOffGameSetting SpiderTrap = new OnOffGameSetting("Spider",
+			"Traps can spawn spiders.", true);
 
 		[DoesNotAffectCompetitiveBalance] 
 		public SpriteGameSetting LunaisSprite = new SpriteGameSetting("Lunais",

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -151,6 +151,7 @@
     <Compile Include="IntermediateObjects\CustomItems\BeeTrap.cs" />
     <Compile Include="IntermediateObjects\CustomItems\ThrowStunTrap.cs" />
     <Compile Include="IntermediateObjects\CustomItems\MeteorSparrowTrap.cs" />
+    <Compile Include="IntermediateObjects\CustomItems\SpiderTrap.cs" />
     <Compile Include="IntermediateObjects\CustomItems\StatusTrap.cs" />
     <Compile Include="IntermediateObjects\CustomItems\Trap.cs" />
     <Compile Include="IntermediateObjects\CustomItems\LaserAccessKey.cs" />


### PR DESCRIPTION
A Spider Trap spawns two Hell Gazers, scaled to the stats of Flesh Arachnids so they're less threatening if encountered early, to the left and right of the player - about as far out as the two Meteor Sparrows from a Sparrow Trap would spawn out, but closer if there's a wall in that direction.

Nasty surprise if you activate one while dashing past a check, and probably less likely to result in weird issues than Throw Stun Traps seem to be.