### PR TITLE
Adjust logic for lore check in Maw cave

### DIFF
--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -591,7 +591,7 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(6, 14, 136, 177), "Royal Towers: Journal - Aelana Boss (Stained Letter)", null, UpperRoyalTower);
 			Add(new ItemKey(6, 25, 152, 145), "Royal Towers: Journal - Near Bottom Struggle Juggle (Mission Findings)", null, MidRoyalTower & (FloodsFlags.CastleCourtyard ? R.Free : DoubleJumpOfNpc));
 			areaName = "Caves of Banishment (Maw)";
-			Add(new ItemKey(8, 36, 136, 145), "Caves of Banishment (Maw): Journal - Lower Left Caves (Naivety)", null, CavesOfBanishmentFlooded);
+			Add(new ItemKey(8, 36, 136, 145), "Caves of Banishment (Maw): Journal - Lower Left Caves (Naivety)", null, CavesOfBanishmentFlooded | (R.GateMaw & NeedSwimming(FloodsFlags.Maw)));
 		}
 
 		ItemLocation GetItemLocationBasedOnKeyOrRoomKey(ItemKey key)


### PR DESCRIPTION
Per discussion on Discord, if we get the warp to Maw cave, this location is not considered to be in logic without double jump; it's quite accessible without double jump (even if it necessitates fighting through a room with several enemies to do so).

Notably, the apworld logic for this check does not require double jump to get to the location, which I'd argue is correct.