### PR TITLE
when receiving custom items in archipelago, show the custom item name…

### DIFF
--- a/TsRandomizer/Archipelago/ArchipelagoItemLocationMap.cs
+++ b/TsRandomizer/Archipelago/ArchipelagoItemLocationMap.cs
@@ -130,7 +130,12 @@ namespace TsRandomizer.Archipelago
 				level.AsDynamic().UnlockRelic(itemIdentifier.Relic);
 
 			if (!firstPass || item.IsProgression)
-				level.ShowItemAwardPopup(itemIdentifier);
+			{
+	                        if (item is CustomItem customItem)
+	                                gameplayScreen.ShowItemPickupBar(customItem.Name);
+				else
+					level.ShowItemAwardPopup(itemIdentifier);
+			}
 
 			if (item.IsProgression)
 				ItemTrackerUplink.UpdateState(ItemTrackerState.FromItemLocationMap(this));


### PR DESCRIPTION
… properly

While watching / testing some AP, I noticed that receiving trap items would show "Map Downloaded: Lake Desolation" instead of the item name.

In the other location where we're using Level.ShowItemAwardPopup - ItemManipulator - there's a special case for custom items which isn't reflected in the AP item receiving code, so we need to update the AP item code to also have the same behaviour for custom items.

(There's also a case in ItemManipulator for progressive items, but the apworld doesn't currently support those so I don't think we currently need to handle that case as well.)