### PR TITLE
Fix Gyre access logic when Risky Warps takes you past the lasers

### DIFF
--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -262,7 +262,7 @@ namespace TsRandomizer.Randomisation
 
 			//pyramid
 			var completeTimespinner = R.TimespinnerPiece1 & R.TimespinnerPiece2 & R.TimespinnerPiece3 & R.TimespinnerSpindle & R.TimespinnerWheel;
-			TemporalGyre = MilitaryFortress & R.TimespinnerWheel;
+			TemporalGyre = MilitaryFortress & militaryLazerGate & R.TimespinnerWheel;
 			PyramidEntrance = (SeedOptions.PyramidStart)
 				? R.Free
 				: (UpperLab & completeTimespinner)


### PR DESCRIPTION
This is an edge case that was uncovered during some Archipelago play which also turns out to be present in the base randomiser.

MilitaryHangarGyreWarp only places the Gyre entrance when all three lasers are gone; accessing the room from the lab side without the lasers being down does not place the Gyre entrance, but logic assumed that Gyre entrance was available if you could get there at all.

Fix by ensuring that Gyre is only in logic when the lasers are down so that the gate exists.

(I've made a corresponding change in the AP pull request.)