### PR TITLE
Fix for Risky Warp Softlocks

### DIFF
--- a/TsRandomizer/Extensions/LevelExtensions.cs
+++ b/TsRandomizer/Extensions/LevelExtensions.cs
@@ -3,6 +3,7 @@ using Timespinner.GameAbstractions.Gameplay;
 using Timespinner.GameObjects.BaseClasses;
 using TsRandomizer.IntermediateObjects;
 
+
 namespace TsRandomizer.Extensions
 {
 	public static class LevelExtensions
@@ -60,6 +61,19 @@ namespace TsRandomizer.Extensions
 
 			minimapRoom.SetKnown(true);
 			minimapRoom.SetVisited(true);
+		}
+
+		internal static bool IsRoomVisited(this Level level, int levelId, int roomId)
+		{
+			var minimapRoom = level.Minimap.Areas[levelId].Rooms.Find(x => x.RoomID == roomId);
+			bool visited = false;
+			foreach (var block in minimapRoom.Blocks.Values)
+				if (block.IsVisited)
+				{
+					visited = true;
+					break;
+				}
+			return visited;
 		}
 	}
 }

--- a/TsRandomizer/RoomTriggers/Triggers/AncientPyramidPitWarp.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/AncientPyramidPitWarp.cs
@@ -15,6 +15,8 @@ namespace TsRandomizer.RoomTriggers.Triggers
 
 		public override void OnRoomLoad(RoomState roomState)
 		{
+			if (roomState.Level.LastRoomIndex == 0) // Loading from save
+				return;
 			// Spawn glowing floor event to give a soft-lock exit warp
 			if (((Dictionary<int, NPCBase>)roomState.Level.AsDynamic()._npcs).Values.Any(npc => npc.GetType() == GlowingFloorEventType)) 
 				return;

--- a/TsRandomizer/RoomTriggers/Triggers/LabSoftlockExits.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/LabSoftlockExits.cs
@@ -12,11 +12,7 @@ namespace TsRandomizer.RoomTriggers.Triggers
 			if (!roomState.Seed.Options.RiskyWarps)
 				return;
 			// Only spawns if you are past the laser but it's still on (i.e. coming from Dad's Tower warp)
-			if (roomState.Level.RoomID == 16 && (
-				// 11_LabPower true = power off
-				!roomState.Level.GameSave.GetSaveBool("11_LabPower")
-				|| (roomState.Seed.Options.LockKeyAmadeus && !roomState.Level.GameSave.HasItem(CustomItem.GetIdentifier(CustomItemType.LabAccessGenza)))
-			))
+			if (!roomState.Level.IsRoomVisited(11, 35))
 				RoomTriggerHelper.SpawnGlowingFloor(roomState.Level, new Point(900, 300));
 		}
 

--- a/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarGyreWarp.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarGyreWarp.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using TsRandomizer.Extensions;
 
 namespace TsRandomizer.RoomTriggers.Triggers
 {
@@ -13,7 +14,9 @@ namespace TsRandomizer.RoomTriggers.Triggers
 					// Military Hangar crash site to Gyre
 					RoomTriggerHelper.SpawnGyreWarp(roomState.Level, 340, 180);
 			}
-			else if (roomState.Seed.Options.RiskyWarps)
+			else if (roomState.Seed.Options.RiskyWarps && !roomState.Level.IsRoomVisited(10, 12))
+				// Spawns only if lasers are still up, coming from right
+				// Soft-lock exit back to lab
 				RoomTriggerHelper.SpawnGlowingFloor(roomState.Level, new Point(360, 120));
 		}
 	}

--- a/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarWarpRoom.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/MilitaryHangarWarpRoom.cs
@@ -1,4 +1,5 @@
 ﻿using TsRandomizer.Randomisation;
+
 namespace TsRandomizer.RoomTriggers.Triggers
 {
 	[RoomTriggerTrigger(10, 12),


### PR DESCRIPTION
Fixes an error seen where entering the hangar from from the left with Risky Warps on and the lasers up could pre-emptively trigger a warp due to a cutscene interfering with the softlock prevention.

As softlock prevention is only relevant if you are on the wrong side of the lasers (due to a risky warp), this does not spawn it if you already have access to the warp room- i.e. the room you would enter from the left.