### PR TITLE
Mac Instructions/Installation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,10 +16,14 @@ Download latest TsRandomizer.exe or Linux / Mac zip file from the release page h
 
 For Windows:
 Extract the contents of the corresponding zip file to the same folder as Timespinner.exe is located, and start TsRandomizer.exe to start the game with the randomizer enabled, or Timespinner.exe to start the game normally
+
 For Linux:
 Extract the contents of the corresponding zip file to the same folder as Timespinner.exe is located, and start TsRandomizer to start the game with the randomizer enabled, or Timespinner to start the game normally
+
 For Mac:
-Copy the contents of the Mac/ folder in the mac zip file to the `Timespinner.app/Contents/MacOS` folder. You may need to run `xattr -dr com.apple.quarantine TsRandomizer TsRandomizer.bin.osx` and `chmod +x TsRandomizer` to make execution possible. Then start TsRandomizer to start the game with the randomizer enabled, or Timespinner to start the game normally.
+Copy the contents of the Mac/ folder in the mac zip file to the `Timespinner.app/Contents/Resources` folder, and in that folder, run: `ln -s ../MacOS/osx/* .`. You may need to run `xattr -dr com.apple.quarantine TsRandomizer TsRandomizer.bin.osx` and `chmod +x TsRandomizer TSRandomizer.bin.osx` to make execution possible. Then start `Timespinner.app/Contents/Resources/TsRandomizer` to start the game with the randomizer enabled, or `Timespinner.app/Contents/MacOS/Timespinner` (or just double-click Timespinner.app) to start the game normally.
+
+To connect to archipelago on mac: after copying the contents of the zip file to `Timespinner.app/Contents/Resources`, additionally copy the contents of `MonoKickStartOSX.zip` from [the MonoKickstart release page](https://github.com/MonoGame/MonoKickstart/releases/tag/v0.0.12), overwriting as necessary. Rename `kick.bin.osx` from there to `TSRandomizer.bin.osx` and overwrite `Timespinner.app/Contents/Resources/TSRandomizer.bin.osx`. This will break launching the vanilla game.
  
 ##### Supported versions
 * Windows Steam version 1.33 (latest)


### PR DESCRIPTION
The install instructions as they are do not work on the GOG mac version, and I suspect the Steam mac version as well; this looks to correct that. While I'd like to streamline the installation process and make archipelago connection work out of the box, this would take more time and open cans of worms like "change the MonoKickstart stuff without breaking Linux," so I figure it's best to _just_ update readme.md with quick and dirty instructions before getting to that.

I'll need a guinea pig with the Steam version to check how well this works, since I don't have the Steam version to test and Steam's DRM/overlay/etc might mess with things.