### PR TITLE
Add Lab Power Safety Adjustments

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -49,6 +49,7 @@ In order to use the randomizer on a steam deck, you will have to install the ran
 * SaveStatues in front of Temportal Gyre bosses Ifrit and Ravenlord are disabled to prevent softlocks
 * Aelana and The Maw no longer require twins to be killed before their door unlocks
 * Softlock exits are conditionally added the Lab and Hangar when Risky Warps are on and certain lasers are active
+* The depowered lab has safeties to ensure certain items are still reachable: lower left trash has a broken gate, upper left trash has engineers throwing trash, and the dynamo shaft has hand-holds.
 
 # New keybinds
 * On the minimap screen, holding the melee button (default: X) will highlight all locations that you can reach and still have items for you

--- a/TsRandomizer/LevelObjects/Monsters/FortressEngineer.cs
+++ b/TsRandomizer/LevelObjects/Monsters/FortressEngineer.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.IntermediateObjects;
+using TsRandomizer.Screens;
+using TsRandomizer.Settings;
+using Microsoft.Xna.Framework;
+using Timespinner.Core.Specifications;
+using TsRandomizer.IntermediateObjects;
+using System;
+using Microsoft.Xna.Framework;
+using TsRandomizer.Extensions;
+
+
+
+namespace TsRandomizer.LevelObjects.Monsters
+{
+	[TimeSpinnerType("Timespinner.GameObjects.Enemies.FortressEngineer")]
+	class FortressEngineer : LevelObject<Monster>
+	{
+		public FortressEngineer(Monster typedObject, GameplayScreen gameplayScreen) : base(typedObject, gameplayScreen)
+		{
+		}
+
+		protected override void Initialize(Seed seed, SettingCollection settings)
+		{
+		}
+
+		protected override void OnUpdate()
+		{
+			// Modified behavior exclusive to new trash jump engineers in lab
+			if (Level.ID != 11)
+				return;
+			Dynamic._aggroBbox = new Rectangle(0, 0, 0, 0);
+			var bombType = TimeSpinnerType.Get("Timespinner.GameAbstractions.GameObjects.FortressEngineerBomb");
+			var sprite = Level.GCM.SpRobotJunk;
+			Point position = Dynamic.Position;
+			position.X += (Dynamic.IsFacingLeft ? -24 : 24);
+			var bomb = (Projectile)bombType.CreateInstance(false, position, Level, sprite, -1, 0);
+			bomb.AsDynamic()._animationStart = 0;
+
+			for (int i = 0; i < 5; i++)
+			{
+				Dynamic._bombBag[i] = bomb;
+			}
+		}
+	}
+}

--- a/TsRandomizer/LevelObjects/Other/LabBlocker.cs
+++ b/TsRandomizer/LevelObjects/Other/LabBlocker.cs
@@ -1,0 +1,24 @@
+﻿using Timespinner.GameAbstractions.Gameplay;
+using Timespinner.GameObjects.BaseClasses;
+using TsRandomizer.IntermediateObjects;
+using TsRandomizer.Screens;
+using TsRandomizer.Settings;
+
+
+namespace TsRandomizer.LevelObjects.Other
+{
+	[TimeSpinnerType("Timespinner.GameObjects.Events.EnvironmentPrefabs.L11_Lab.EnvPrefabLabPlayerBlocker")]
+	// ReSharper disable once UnusedMember.Global
+	class LabBlocker : LevelObject
+	{
+		public LabBlocker(Mobile typedObject, GameplayScreen gameplayScreen) : base(typedObject, gameplayScreen)
+		{
+		}
+
+		protected override void Initialize(Seed seed, SettingCollection settings)
+		{
+			if (!seed.Options.LockKeyAmadeus && Level.GameSave.GetSaveBool("11_LabPower"))
+				Dynamic.SilentKill();
+		}
+	}
+}

--- a/TsRandomizer/LevelObjects/Other/LabLaser.cs
+++ b/TsRandomizer/LevelObjects/Other/LabLaser.cs
@@ -22,6 +22,10 @@ namespace TsRandomizer.LevelObjects.Other
 
 		protected override void Initialize(Seed seed, SettingCollection settings)
 		{
+			// Lower Trash
+			if (Level.RoomID == 3)
+				Dynamic.IsTriggerableByMonsters = false;
+
 			if (Level.RoomID > 30)
 				doRainbow = seed.Id % Level.RoomID < 3;
 			else

--- a/TsRandomizer/Randomisation/ItemLocationMap.cs
+++ b/TsRandomizer/Randomisation/ItemLocationMap.cs
@@ -394,11 +394,11 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(10, 18, 280, 189), "Military Fortress: Pedestal", ItemProvider.Get(EInventoryOrbType.Gun, EOrbSlot.Melee), LabEntrance & (FloodsFlags.Lab ? R.Free : DoubleJumpOfNpc | ForwardDashDoubleJump));
 			areaName = "The Lab";
 			Add(new ItemKey(11, 36, 312, 192), "Lab: Coffee break", ItemProvider.Get(EInventoryUseItemType.FoodSynth), MainLab);
-			Add(new ItemKey(11, 3, 1528, 192), "Lab: Lower trash right", ItemProvider.Get(EItemType.MaxHP), MainLab & (FloodsFlags.Lab ? R.Free : R.DoubleJump));
-			Add(new ItemKey(11, 3, 72, 192), "Lab: Lower trash left", ItemProvider.Get(EInventoryUseItemType.FuturePotion), MainLab & (FloodsFlags.Lab ? R.Free : (SeedOptions.LockKeyAmadeus ? DoubleJumpOfNpc: R.UpwardDash))); // When lab power is on, it only requires DoubleJumpOfNpc, but we cant code for the power state
+			Add(new ItemKey(11, 3, 1528, 192), "Lab: Lower Trash Right", ItemProvider.Get(EItemType.MaxHP), MainLab & (FloodsFlags.Lab ? R.Free : R.DoubleJump));
+			Add(new ItemKey(11, 3, 72, 192), "Lab: Lower Trash Left", ItemProvider.Get(EInventoryUseItemType.FuturePotion), MainLab & (FloodsFlags.Lab ? R.Free : DoubleJumpOfNpc));
 			Add(new ItemKey(11, 25, 104, 192), "Lab: Below lab entrance", ItemProvider.Get(EItemType.MaxAura), MainLab & (FloodsFlags.Lab ? R.Swimming : R.DoubleJump));
-			Add(new ItemKey(11, 18, 824, 128), "Lab: Trash jump room", ItemProvider.Get(EInventoryUseItemType.ChaosHeal), MainLab & (SeedOptions.LockKeyAmadeus ? DoubleJumpOfNpc : R.UpwardDash)); // Only requires DoubleJumpOffNpc when lab power is on
-			Add(new RoomItemKey(11, 39), "Lab: Dynamo Works", ItemProvider.Get(EInventoryOrbType.Eye, EOrbSlot.Melee), SeedOptions.LockKeyAmadeus ? LabResearchWing & R.LabDynamo & R.UpwardDash : LabResearchWing); // Blast door is closed in Lock Key Amadeus
+			Add(new ItemKey(11, 18, 824, 128), "Lab: Trash jump room", ItemProvider.Get(EInventoryUseItemType.ChaosHeal), MainLab & DoubleJumpOfNpc);
+			Add(new RoomItemKey(11, 39), "Lab: Dynamo Works", ItemProvider.Get(EInventoryOrbType.Eye, EOrbSlot.Melee), LabResearchWing & (SeedOptions.LockKeyAmadeus ?  R.LabDynamo & R.UpwardDash : R.Free)); // Blast door is closed in Lock Key Amadeus
 			Add(new RoomItemKey(11, 21), "Lab: Genza (Blob Mom)", ItemProvider.Get(EInventoryRelicType.ScienceKeycardA), UpperLab);
 			Add(new RoomItemKey(11, 1), "Lab: Experiment #13", ItemProvider.Get(EInventoryRelicType.Dash), SeedOptions.LockKeyAmadeus ? MainLab & R.LabExperiment : LabResearchWing);
 			Add(new ItemKey(11, 6, 328, 192), "Lab: Download and chest room chest", ItemProvider.Get(EInventoryEquipmentType.LabCoat), UpperLab);
@@ -821,14 +821,14 @@ namespace TsRandomizer.Randomisation
 			Add(new ItemKey(11, 22, 280, 505), "Lab: File Cabinet Staircase Lantern 4", null, UpperLab & LanternCube);
 			Add(new ItemKey(11, 17, 216, 281), "Lab: Trash Stairs Lantern 1", null, MainLab & LanternCube);
 			Add(new ItemKey(11, 17, 120, 505), "Lab: Trash Stairs Lantern 2", null, MainLab & LanternCube);
-			Add(new ItemKey(11, 18, 126, 144), "Lab: Trash Jump Lantern 1", null, MainLab & (SeedOptions.LockKeyAmadeus ? DoubleJumpOfNpc : R.UpwardDash) & LanternCube);
-			Add(new ItemKey(11, 18, 782, 112), "Lab: Trash Jump Lantern 2", null, MainLab & (SeedOptions.LockKeyAmadeus ? DoubleJumpOfNpc : R.UpwardDash) & LanternCube);
+			Add(new ItemKey(11, 18, 126, 144), "Lab: Trash Jump Lantern 1", null, MainLab & R.DoubleJump & LanternCube);
+			Add(new ItemKey(11, 18, 782, 112), "Lab: Trash Jump Lantern 2", null, MainLab & DoubleJumpOfNpc & LanternCube);
 			Add(new ItemKey(11, 19, 120, 169), "Lab: Genza Door Lantern 1", null, UpperLab & LanternCube);
 			Add(new ItemKey(11, 19, 264, 169), "Lab: Genza Door Lantern 2", null, UpperLab & LanternCube);
 			Add(new ItemKey(11, 23, 104, 169), "Lab: Spider Hell Entrance Lantern 1", null, LabResearchWing & R.CardA & LanternCube);
 			Add(new ItemKey(11, 23, 280, 169), "Lab: Spider Hell Entrance Lantern 2", null, LabResearchWing & R.CardA & LanternCube);
-			Add(new ItemKey(11, 3, 1448, 489), "Lab: Lower Trash Lantern 1", null, MainLab & (FloodsFlags.Lab ? R.Free : (SeedOptions.LockKeyAmadeus ? DoubleJumpOfNpc : R.UpwardDash)) & LanternCube);
-			Add(new ItemKey(11, 3, 152, 489), "Lab: Lower Trash Lantern 2", null, MainLab & (FloodsFlags.Lab ? R.Free : (SeedOptions.LockKeyAmadeus ? DoubleJumpOfNpc : R.UpwardDash)) & LanternCube);
+			Add(new ItemKey(11, 3, 1448, 489), "Lab: Lower Trash Lantern 1", null, MainLab & NeedSwimming(FloodsFlags.Lab) & LanternCube);
+			Add(new ItemKey(11, 3, 152, 489), "Lab: Lower Trash Lantern 2", null, MainLab & NeedSwimming(FloodsFlags.Lab) & LanternCube);
 			Add(new ItemKey(11, 30, 152, 169), "Lab: Intro Hallway Lantern 1", null, LabEntrance & LanternCube);
 			Add(new ItemKey(11, 30, 264, 169), "Lab: Intro Hallway Lantern 2", null, LabEntrance & LanternCube);
 			Add(new ItemKey(11, 34, 136, 169), "Lab: Exp. 13 Terminal Lantern 1", null, MainLab & LanternCube);

--- a/TsRandomizer/RoomTriggers/Triggers/LabPowerChanges.cs
+++ b/TsRandomizer/RoomTriggers/Triggers/LabPowerChanges.cs
@@ -1,0 +1,186 @@
+﻿using Timespinner.Core.Specifications;
+using TsRandomizer.IntermediateObjects;
+using System;
+using Microsoft.Xna.Framework;
+using TsRandomizer.Extensions;
+
+
+namespace TsRandomizer.RoomTriggers.Triggers
+{
+	[RoomTriggerTrigger(11, 3)]
+	class LabLowerTrash : RoomTrigger
+	{
+		static readonly Type LaserType = TimeSpinnerType.Get("Timespinner.GameObjects.Events.EnvironmentPrefabs.L11_Lab.EnvPrefabLabForceField");
+		public override void OnRoomLoad(RoomState roomState)
+		{
+
+			if (roomState.Seed.Options.LockKeyAmadeus)
+				return;
+
+			Point[] lasers = new[] { new Point(492, 112), new Point(516, 112) };
+			foreach (Point point in lasers)
+			{
+				var laser = LaserType.CreateInstance(false, roomState.Level, point, -1, new ObjectTileSpecification(), Timespinner.GameObjects.Events.EnvironmentPrefabs.EEnvironmentPrefabType.L11_ForceField);
+				roomState.Level.AsDynamic().RequestAddObject(laser);
+			}
+
+			// Remove barrier wall tiles if powered down
+			if (roomState.Level.GameSave.GetSaveBool("11_LabPower"))
+            {
+				TileSpecification[] tiles = new[] {
+					new TileSpecification { ID = 510, X = 31, Y = 6, Layer = ETileLayerType.Top },
+					new TileSpecification { ID = 510, X = 31, Y = 5, Layer = ETileLayerType.Top },
+					new TileSpecification { ID = 510, X = 31, Y = 4, Layer = ETileLayerType.Top },
+					new TileSpecification { ID = 510, X = 31, Y = 3, Layer = ETileLayerType.Top }
+					};
+				foreach (TileSpecification tile in tiles)
+				{
+					roomState.Level.ReplaceTile(tile);
+				}
+			}
+		}
+	}
+	[RoomTriggerTrigger(11, 18)]
+	class LabUpperTrash : RoomTrigger
+	{
+		struct Engineer
+		{
+			public Point position;
+			public bool isFlipped;
+		}
+		public override void OnRoomLoad(RoomState roomState)
+		{
+			// Only run room trigger when power is off
+			if (roomState.Seed.Options.LockKeyAmadeus || !roomState.Level.GameSave.GetSaveBool("11_LabPower"))
+			  return;
+
+			TileSpecification[] replaceTiles = new[] {
+				new TileSpecification { ID = 22, X = 15, Y = 2, Layer = ETileLayerType.Middle},
+				new TileSpecification { ID = 22, X = 16, Y = 2, Layer = ETileLayerType.Middle},
+				new TileSpecification { ID = 22, X = 21, Y = 2, Layer = ETileLayerType.Middle},
+				new TileSpecification { ID = 22, X = 22, Y = 2, Layer = ETileLayerType.Middle},
+				new TileSpecification { ID = 22, X = 29, Y = 2, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 22, X = 30, Y = 2, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 22, X = 35, Y = 2, Layer = ETileLayerType.Middle},
+				new TileSpecification { ID = 22, X = 36, Y = 2, Layer = ETileLayerType.Middle},
+			};
+			foreach (TileSpecification tile in replaceTiles)
+			{
+				roomState.Level.ReplaceTile(tile);
+			}
+
+			Engineer[] engineers = new[] {
+				 new Engineer
+				 {
+					position = new Point(256, 16),
+					isFlipped = true
+				 },
+				 new Engineer
+				 {
+					position = new Point(352, 16),
+					isFlipped = false
+				 },
+				 new Engineer
+				 {
+					position = new Point(480, 16),
+					isFlipped = true
+				 },
+				 new Engineer
+				 {
+					position = new Point(576, 16),
+					isFlipped = false
+				 },
+			};
+			var enemyTile = new ObjectTileSpecification
+			{
+				Category = EObjectTileCategory.Enemy,
+				Layer = ETileLayerType.Objects,
+				ObjectID = (int)EEnemyTileType.FortressEngineer,
+				Argument = 1,
+				IsFlippedHorizontally = false
+			};
+			var enemyType = TimeSpinnerType.Get("Timespinner.GameObjects.Enemies.FortressEngineer");
+			var sprite = roomState.Level.GCM.SpFortressEngineer;
+			foreach (Engineer engineer in engineers)
+			{
+				enemyTile.IsFlippedHorizontally = engineer.isFlipped;
+				var enemy = enemyType.CreateInstance(false, engineer.position, roomState.Level, sprite, -1, enemyTile);
+				enemy.AsDynamic().InitializeMob();
+				roomState.Level.AsDynamic().RequestAddObject(enemy);
+			}
+		}
+	}
+
+	[RoomTriggerTrigger(11, 2)]
+	class DynamoShaft : RoomTrigger
+	{
+		public override void OnRoomLoad(RoomState roomState)
+		{
+			// Power is always off here except during Lock Key Amadeus
+			if (roomState.Seed.Options.LockKeyAmadeus)
+				return;
+			TileSpecification[] deleteTiles = new[] {
+				new TileSpecification { ID = 513, X = 9, Y = 20, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 15, Y = 27, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 9, Y = 34, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 15, Y = 41, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 9, Y = 48, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 15, Y = 55, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 9, Y = 62, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 15, Y = 69, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 9, Y = 76, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 15, Y = 83, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 9, Y = 90, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 15, Y = 97, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 9, Y = 104, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 513, X = 15, Y = 106, Layer = ETileLayerType.Middle },
+			};
+			foreach (TileSpecification tile in deleteTiles)
+			{
+				roomState.Level.DeleteTile(tile);
+			}
+			// Set Background
+			foreach (TileSpecification tile in deleteTiles)
+			{
+				tile.ID = 258;
+				tile.Layer = ETileLayerType.Bottom;
+				roomState.Level.PlaceTile(tile, true);
+			}
+			TileSpecification[] replaceTiles = new[] {
+				new TileSpecification { ID = 21, X = 9, Y = 19, Layer = ETileLayerType.Middle, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 9, Y = 21, Layer = ETileLayerType.Middle},
+				new TileSpecification { ID = 21, X = 15, Y = 26, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 15, Y = 28, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true},
+				new TileSpecification { ID = 21, X = 9, Y = 33, Layer = ETileLayerType.Middle, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 9, Y = 35, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 21, X = 15, Y = 40, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 15, Y = 42, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true },
+				new TileSpecification { ID = 21, X = 9, Y = 47, Layer = ETileLayerType.Middle, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 9, Y = 49, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 21, X = 15, Y = 54, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 15, Y = 56, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true },
+				new TileSpecification { ID = 21, X = 9, Y = 61, Layer = ETileLayerType.Middle, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 9, Y = 63, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 21, X = 15, Y = 68, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 15, Y = 70, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true },
+				new TileSpecification { ID = 21, X = 9, Y = 75, Layer = ETileLayerType.Middle, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 9, Y = 77, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 21, X = 15, Y = 82, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 15, Y = 84, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true },
+				new TileSpecification { ID = 21, X = 9, Y = 89, Layer = ETileLayerType.Middle, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 9, Y = 91, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 21, X = 15, Y = 96, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 15, Y = 98, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true },
+				new TileSpecification { ID = 21, X = 9, Y = 103, Layer = ETileLayerType.Middle, IsFlippedVertically = true },
+				new TileSpecification { ID = 21, X = 9, Y = 105, Layer = ETileLayerType.Middle },
+				new TileSpecification { ID = 21, X = 15, Y = 105, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true, IsFlippedVertically = true },
+				new TileSpecification { ID = 22, X = 15, Y = 107, Layer = ETileLayerType.Middle, IsFlippedHorizontally = true },
+				new TileSpecification { ID = 22, X = 16, Y = 107, Layer = ETileLayerType.Middle },
+			};
+			foreach (TileSpecification tile in replaceTiles)
+			{
+				roomState.Level.ReplaceTile(tile);
+			}
+		}
+	}
+}

--- a/TsRandomizer/TsRandomizer.csproj
+++ b/TsRandomizer/TsRandomizer.csproj
@@ -167,11 +167,13 @@
     <Compile Include="LevelObjects\ItemManipulators\JournalMemoryEvent+JournalLetterEvent.cs" />
     <Compile Include="LevelObjects\ItemManipulators\Lantern.cs" />
     <Compile Include="LevelObjects\Monsters\Bee.cs" />
+    <Compile Include="LevelObjects\Monsters\FortressEngineer.cs" />
     <Compile Include="LevelObjects\Monsters\Demon.cs" />
     <Compile Include="LevelObjects\Monsters\CastleLargeSoldier.cs" />
     <Compile Include="LevelObjects\Monsters\LabTrashSpawner.cs" />
     <Compile Include="LevelObjects\Monsters\LabTurret.cs" />
     <Compile Include="LevelObjects\Monsters\TowerPlasmaPod.cs" />
+    <Compile Include="LevelObjects\Other\LabBlocker.cs" />
     <Compile Include="LevelObjects\Other\BlastDoorEvent.cs" />
     <Compile Include="LevelObjects\Other\LabPowerCore.cs" />
     <Compile Include="LevelObjects\Other\LabLaser.cs" />
@@ -200,6 +202,7 @@
     <Compile Include="RisingTides.cs" />
     <Compile Include="Randomisation\BestiaryManager.cs" />
     <Compile Include="RoomTriggers\Triggers\Bosses\AzureQueen.cs" />
+    <Compile Include="RoomTriggers\Triggers\LabPowerChanges.cs" />
     <Compile Include="RoomTriggers\Triggers\MetropolisBridgeLanterns.cs" />
     <Compile Include="RoomTriggers\Triggers\LabSoftlockExits.cs" />
     <Compile Include="RoomTriggers\Triggers\LabExperimentRooms.cs" />


### PR DESCRIPTION
Adds "safety" options for the four checks affected by the lab's power state.

Before, we had to make the logic for them restrictive to require infinite vertical, despite all four being reachable with just timestop and double jump when the lab is powered.

This PR makes it so that alternative routes that only need double jump and not infinite are available after shutting off power.

1. The two checks in upper trash have starship engineers manually throwing trash.
2. The one check in lower trash right has laser gates around the wall, and the wall is destroyed when power is cut off.
3. The dynamo shaft has handholds.

----
Note that none of the above changes apply when the lab is powered, which also means they will never apply in LockKeyAmadeus.

Videos are too large to attach here and are provided in the discord.
