### PR TITLE
Show Goal and Statistics in the Journal

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -123,6 +123,4 @@ There exist several programs that can extract XNB files into an editable image f
 
 # Ideas
 ##### Ideas that may never happen but I think will be fun when they are implemented:
-* Randomize quest items
 * Timesanity (entrance randomizer)
-* Make warpshard optionally a progression item that unlocks all softlocks

--- a/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
+++ b/TsRandomizer/LevelObjects/Monsters/BossEnemy.cs
@@ -170,6 +170,7 @@ namespace TsRandomizer.LevelObjects.Monsters
 				if (isFinalBoss)
 				{
 					Level.GameSave.SetValue("CreditsActive", true);
+					Level.GameSave.SetValue("TsRandoGoalCleared", true);
 					var fillingMethod = Level.GameSave.GetFillingMethod();
 
 					if (fillingMethod == FillingMethod.Archipelago)

--- a/TsRandomizer/Screens/FeatsMenuCollection.cs
+++ b/TsRandomizer/Screens/FeatsMenuCollection.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections;
+using Microsoft.Xna.Framework;
+using Timespinner.GameAbstractions;
+using Timespinner.GameStateManagement.ScreenManager;
+using TsRandomizer.Extensions;
+using TsRandomizer.IntermediateObjects;
+using TsRandomizer.Randomisation;
+using TsRandomizer.Screens.Menu;
+
+namespace TsRandomizer.Screens
+{
+	[TimeSpinnerType("Timespinner.GameStateManagement.Screens.PauseMenu.Journal.FeatsMenuEntryCollection")]
+	// ReSharper disable once UnusedMember.Global
+	class FeatsMenuEntryCollection : Screen
+	{
+		static readonly Type FeatsMenuEntryType = TimeSpinnerType.Get("Timespinner.GameStateManagement.Screens.BaseClasses.Inventory.FeatsMenuEntry");
+
+		public FeatsMenuEntryCollection(ScreenManager screenManager, GameScreen gameScreen) : base(screenManager, gameScreen)
+		{
+		}
+
+		public override void Initialize(ItemLocationMap itemLocationMap, GCM gameContentManager)
+		{
+			var buttons = (IList)((object)Dynamic._primaryMenuCollection).AsDynamic()._entries;
+
+			var testButton = MenuEntry.Create("Test Achievement", NullAction);
+			buttons.Add(testButton.AsTimeSpinnerMenuEntry());
+			((object)Dynamic._featsEntries).AsDynamic()._entries = buttons.ToList(FeatsMenuEntryType);
+		}
+
+		void NullAction(PlayerIndex playerIndex)
+		{
+		}
+	}
+}

--- a/TsRandomizer/Seed.cs
+++ b/TsRandomizer/Seed.cs
@@ -12,8 +12,7 @@ namespace TsRandomizer
 	public enum Goal
 	{
 		Nightmare,
-		DadPercent,
-		Objectives
+		DadPercent
 	}
 	struct Seed
 	{

--- a/TsRandomizer/Seed.cs
+++ b/TsRandomizer/Seed.cs
@@ -9,6 +9,12 @@ namespace TsRandomizer
 		Present,
 		Pyramid
 	}
+	public enum Goal
+	{
+		Nightmare,
+		DadPercent,
+		Objectives
+	}
 	struct Seed
 	{
 		public const int Length = 8 + SeedOptions.Length;
@@ -17,6 +23,7 @@ namespace TsRandomizer
 		public readonly SeedOptions Options;
 		public readonly RisingTides FloodFlags;
 		public readonly Era StartingEra;
+		public readonly Goal GoalState;
 
 		public static Seed Zero = new Seed(0U, SeedOptions.None);
 
@@ -30,6 +37,9 @@ namespace TsRandomizer
 				StartingEra = Era.Pyramid;
 			else if (options.Inverted)
 				StartingEra = Era.Past;
+			GoalState = Goal.Nightmare;
+			if (options.DadPercent)
+				GoalState = Goal.DadPercent;
 		}
 
 		public static Seed GenerateRandom(SeedOptions options, Random random)


### PR DESCRIPTION
This PR replaces the "Quests" and "Feats" menus in the journal which are unused in the randomizer with "Statistics", which can show information about the seed, and "Objectives" which shows win conditions

While "Objectives" currently has a single "Goal" objective, representing the two win states, the motivator for changing this menu is to support an upcoming win state where the goal is to to complete a number of additional tasks from a provide list before performing the goal state; these tasks would include tasks that are currently feats and quests, which is why those menus are being replaced.

As this is a much more involved feature, this will be worked on later, but the UI changes could be leveraged now with our current win conditions.


<img width="959" height="717" alt="image" src="https://github.com/user-attachments/assets/8a0c7adf-e912-4607-aaf3-05af376038ba" />
<img width="951" height="713" alt="image" src="https://github.com/user-attachments/assets/77e5ee9a-20ae-4338-9825-d16f5c4697e9" />
